### PR TITLE
Use same default colors as the ISE. Colors are pulled from $PSISE.Options.TokenColors. Update and add more unit tests to cover tokens classification 

### DIFF
--- a/PowerShellTools.Test/ClassifierService.Test.cs
+++ b/PowerShellTools.Test/ClassifierService.Test.cs
@@ -12,40 +12,235 @@ namespace PowerShellTools.Test
     {
         private ClassifierService _classifierService;
         private Mock<IClassificationTypeRegistryService> _classificationRegistry;
-        private Mock<IClassificationType> _variableType;
+        private Mock<IClassificationType> _attributeType;
+        private Mock<IClassificationType> _commandType;
+        private Mock<IClassificationType> _commandArgumentType;
+        private Mock<IClassificationType> _commandParameterType;
+        private Mock<IClassificationType> _commentType;
+        private Mock<IClassificationType> _keywordType;
+        private Mock<IClassificationType> _numberType;
+        private Mock<IClassificationType> _operatorType;
         private Mock<IClassificationType> _stringType;
+        private Mock<IClassificationType> _typeType;
+        private Mock<IClassificationType> _variableType;
+        private Mock<IClassificationType> _memberType;
+        private Mock<IClassificationType> _groupStartType;
+        private Mock<IClassificationType> _groupEndType;
+        private Mock<IClassificationType> _lineContinuationType;
+        private Mock<IClassificationType> _loopLabelType;
+        private Mock<IClassificationType> _newLineType;
+        private Mock<IClassificationType> _positionType;
+        private Mock<IClassificationType> _statementSeparatorType;
 
         [TestInitialize]
         public void Init()
         {
             _classificationRegistry = new Mock<IClassificationTypeRegistryService>();
 
-            _variableType = new Mock<IClassificationType>();
-            _variableType.Setup(m => m.Classification).Returns("variable");
-            _classificationRegistry.Setup(m => m.GetClassificationType(Classifications.PowerShellVariable)).Returns(_variableType.Object);
+            TypeSetupHelper(out _attributeType, Classifications.PowerShellAttribute);
+            TypeSetupHelper(out _commandType, Classifications.PowerShellCommand);
+            TypeSetupHelper(out _commandArgumentType, Classifications.PowerShellCommandArgument);
+            TypeSetupHelper(out _commandParameterType, Classifications.PowerShellCommandParameter);
+            TypeSetupHelper(out _commentType, Classifications.PowerShellComment);
+            TypeSetupHelper(out _keywordType, Classifications.PowerShellKeyword);
+            TypeSetupHelper(out _numberType, Classifications.PowerShellNumber);
+            TypeSetupHelper(out _operatorType, Classifications.PowerShellOperator);
+            TypeSetupHelper(out _stringType, Classifications.PowerShellString);
+            TypeSetupHelper(out _typeType, Classifications.PowerShellType);
+            TypeSetupHelper(out _variableType, Classifications.PowerShellVariable);
+            TypeSetupHelper(out _memberType, Classifications.PowerShellMember);
+            TypeSetupHelper(out _groupStartType, Classifications.PowerShellGroupStart);
+            TypeSetupHelper(out _groupEndType, Classifications.PowerShellGroupEnd);
+            TypeSetupHelper(out _lineContinuationType, Classifications.PowerShellLineContinuation);
+            TypeSetupHelper(out _loopLabelType, Classifications.PowerShellLoopLabel);
+            TypeSetupHelper(out _newLineType, Classifications.PowerShellNewLine);
+            TypeSetupHelper(out _positionType, Classifications.PowerShellPosition);
+            TypeSetupHelper(out _statementSeparatorType, Classifications.PowerShellStatementSeparator);
 
-            _stringType = new Mock<IClassificationType>();
-            _stringType.Setup(m => m.Classification).Returns("string");
-            _classificationRegistry.Setup(m => m.GetClassificationType(Classifications.PowerShellString)).Returns(_stringType.Object);
-            
             EditorImports.ClassificationTypeRegistryService = _classificationRegistry.Object;
             _classifierService = new ClassifierService();
         }
 
         [TestMethod]
+        public void ShouldClassifyAttribute()
+        {
+            var script =
+@"param(
+[parameter(Mandatory=$true)]
+[string]$someStr
+)";
+            ClassifyPowershellTokensTestHelper(script, 4, Classifications.PowerShellAttribute);
+        }
+
+        [TestMethod]
+        public void ShouldClassifyCommand()
+        {
+            var script = "Write-Host \"Command here\"";
+
+            ClassifyPowershellTokensTestHelper(script, 0, Classifications.PowerShellCommand);
+        }
+
+        [TestMethod]
+        public void ShouldClassifyCommandParameter()
+        {
+            var script = "Invoke-Command -Computername \"MyComputer\"";
+
+            ClassifyPowershellTokensTestHelper(script, 1, Classifications.PowerShellCommandParameter);
+        }
+
+        [TestMethod]
+        public void ShouldClassifyCommandArgument()
+        {
+            var script = @"New-Item -Path $myPath -ItemType File";
+
+            ClassifyPowershellTokensTestHelper(script, 4, Classifications.PowerShellCommandArgument);
+        }
+
+        [TestMethod]
+        public void ShouldClassifyComment()
+        {
+            var script = @"<# Comment
+                            Comment
+                            #>
+                            param(
+                            [parameter(Mandatory=$true)]
+                            [string]$someStr
+                            )
+                            # See if there are changes, so that we do not unnecessarily change contents.
+                            # This will also allow us to run the script multiple times.
+                            if($replacedBody -ne $body) {
+                                $fileChanged = $true
+                            }";
+
+
+            ClassifyPowershellTokensTestHelper(script, 0, Classifications.PowerShellComment);
+            ClassifyPowershellTokensTestHelper(script, 21, Classifications.PowerShellComment);
+        }
+
+        [TestMethod]
+        public void ShouldClassifyGroupStartAndEnd()
+        {
+            var script = @"param(
+                            [parameter(Mandatory=$true)]
+                            [string]$someStr
+                            )";
+
+
+            ClassifyPowershellTokensTestHelper(script, 1, Classifications.PowerShellGroupStart);
+            ClassifyPowershellTokensTestHelper(script, 17, Classifications.PowerShellGroupEnd);
+        }
+
+        [TestMethod]
+        public void ShouldClassifyKeyword()
+        {
+            var script = @"if($myValue)
+                            { }
+                            function EnsureTrailingSeparator([string] $dirPath) {
+                                return $dirPath
+                            }";
+
+            ClassifyPowershellTokensTestHelper(script, 0, Classifications.PowerShellKeyword);
+            ClassifyPowershellTokensTestHelper(script, 8, Classifications.PowerShellKeyword);
+        }
+
+        [TestMethod]
+        public void ShouldClassifyLineContinuation()
+        {
+            var script = @"New-Item -Path $myPath `
+                            -ItemType File";
+
+            ClassifyPowershellTokensTestHelper(script, 3, Classifications.PowerShellLineContinuation);
+        }
+
+        [TestMethod]
+        public void ShouldClassifyLoopLabel()
+        {
+            var script = @":outerlooplabel for ($i = 0; $i -lt 10; $i++) {
+                              for ($j = 0; $j -lt 10; $j++) {
+                                if ($j -eq ) {
+                                  break outerlooplabel
+                                }
+                              }
+                            }";
+
+            ClassifyPowershellTokensTestHelper(script, 0, Classifications.PowerShellLoopLabel);
+        }
+
+        [TestMethod]
+        public void ShouldClassifyMember()
+        {
+            var script = @"param(
+                            [parameter(Mandatory=$true)]
+                            [string]$someStr
+                            )";
+
+            ClassifyPowershellTokensTestHelper(script, 6, Classifications.PowerShellMember);
+        }
+
+        [TestMethod]
+        public void ShouldClassifyNewLine()
+        {
+            var script = @"param(
+                            [parameter(Mandatory=$true)]
+                            [string]$someStr
+                            )";
+
+            ClassifyPowershellTokensTestHelper(script, 2, Classifications.PowerShellNewLine);
+            ClassifyPowershellTokensTestHelper(script, 11, Classifications.PowerShellNewLine);
+        }
+
+        [TestMethod]
+        public void ShouldClassifyNumber()
+        {
+            var script = "$number=2";
+
+            ClassifyPowershellTokensTestHelper(script, 2, Classifications.PowerShellNumber);
+        }
+
+        [TestMethod]
+        public void ShouldClassifyOperator()
+        {
+            var script = @"param(
+                            [parameter(Mandatory=$true)]
+                            [string]$someStr
+                            )";
+
+            ClassifyPowershellTokensTestHelper(script, 3, Classifications.PowerShellOperator);
+            ClassifyPowershellTokensTestHelper(script, 7, Classifications.PowerShellOperator);
+        }
+
+        [TestMethod]
+        public void ShouldClassifyStatementSeparator()
+        {
+            var script = @"Invoke-Command -Computername 'MyComputer';$number=2;";
+
+            ClassifyPowershellTokensTestHelper(script, 3, Classifications.PowerShellStatementSeparator);
+            ClassifyPowershellTokensTestHelper(script, 7, Classifications.PowerShellStatementSeparator);
+        }
+
+        [TestMethod]
+        public void ShouldClassifyType()
+        {
+            var script = @"function TestType([string]$stringType, [bool]$boolType = $false) {
+                                [string]$newStr = $stringType
+                                return $newStr
+                            }";
+
+            ClassifyPowershellTokensTestHelper(script, 4, Classifications.PowerShellType);
+            ClassifyPowershellTokensTestHelper(script, 9, Classifications.PowerShellType);
+            ClassifyPowershellTokensTestHelper(script, 18, Classifications.PowerShellType);
+        }
+
+        [TestMethod]
         public void ShouldClassifyVariable()
         {
-            var script = "$variable";
+            var script = @"function TestType([string]$stringType, [bool]$boolType = $false) {
+                                [string]$newStr = $stringType
+                                return $newStr
+                            }";
 
-            Token[] tokens;
-            ParseError[] errors;
-            Parser.ParseInput(script, out tokens, out errors);
-
-
-
-            var infos = _classifierService.ClassifyTokens(tokens, 0);
-
-            Assert.AreEqual("variable", infos.ElementAt(0).ClassificationType.Classification);
+            ClassifyPowershellTokensTestHelper(script, 6, Classifications.PowerShellVariable);
+            ClassifyPowershellTokensTestHelper(script, 11, Classifications.PowerShellVariable);
         }
 
         [TestMethod]
@@ -53,14 +248,27 @@ namespace PowerShellTools.Test
         {
             var script = "\"$variable in a string\"";
 
+            ClassifyPowershellTokensTestHelper(script, 0, Classifications.PowerShellString);
+
+            ClassifyPowershellTokensTestHelper(script, 1, Classifications.PowerShellVariable);
+        }
+
+        private void ClassifyPowershellTokensTestHelper(string script, int targetToken, string expectedTypes)
+        {
             Token[] tokens;
             ParseError[] errors;
             Parser.ParseInput(script, out tokens, out errors);
 
-            var infos = _classifierService.ClassifyTokens(tokens, 0);
+            var infos = _classifierService.ClassifyTokens(tokens, 0).ToArray();
 
-            Assert.AreEqual("string", infos.ElementAt(0).ClassificationType.Classification);
-            Assert.AreEqual("variable", infos.ElementAt(1).ClassificationType.Classification);
+            Assert.AreEqual(expectedTypes, infos[targetToken].ClassificationType.Classification);
+        }
+
+        private void TypeSetupHelper(out Mock<IClassificationType> type, string classificationType)
+        {
+            type = new Mock<IClassificationType>();
+            type.Setup(m => m.Classification).Returns(classificationType);
+            _classificationRegistry.Setup(m => m.GetClassificationType(classificationType)).Returns(type.Object);            
         }
     }
 }

--- a/PowerShellTools/Classification/ClassificationType.cs
+++ b/PowerShellTools/Classification/ClassificationType.cs
@@ -21,7 +21,7 @@ namespace PowerShellTools.Classification
         public const string PowerShellMember = "PowerShellMember";
         public const string PowerShellGroupStart = "PowerShellGroupStart";
         public const string PowerShellGroupEnd = "PowerShellGroupEnd";
-        public const string PowerShellLineCotinuation = "PowerShellLineCotinuation";
+        public const string PowerShellLineContinuation = "PowerShellLineContinuation";
         public const string PowerShellLoopLabel = "PowerShellLoopLabel";
         public const string PowerShellNewLine = "PowerShellNewLine";
         public const string PowerShellPosition = "PowerShellPosition";

--- a/PowerShellTools/Classification/ClassificationType.cs
+++ b/PowerShellTools/Classification/ClassificationType.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.Composition;
+using System.Windows.Media;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Utilities;
 
@@ -36,6 +37,10 @@ namespace PowerShellTools.Classification
     [Order(After = Priority.Default, Before = Priority.High)]
     internal sealed class PowerShellAttributeFormat : ClassificationFormatDefinition
     {
+        public PowerShellAttributeFormat()
+        {
+            ForegroundColor = Color.FromArgb(255, 0, 191, 255);
+        }
     }
 
     [Export(typeof(EditorFormatDefinition))]
@@ -46,6 +51,10 @@ namespace PowerShellTools.Classification
     [Order(After = Priority.Default, Before = Priority.High)]
     internal sealed class PowerShellCommandFormat : ClassificationFormatDefinition
     {
+        public PowerShellCommandFormat()
+        {
+            ForegroundColor = Color.FromArgb(255, 0, 0, 255);
+        }
     }
 
     [Export(typeof(EditorFormatDefinition))]
@@ -56,6 +65,10 @@ namespace PowerShellTools.Classification
     [Order(After = Priority.Default, Before = Priority.High)]
     internal sealed class PowerShellCommandArgumentFormat : ClassificationFormatDefinition
     {
+        public PowerShellCommandArgumentFormat()
+        {
+            ForegroundColor = Color.FromArgb(255, 138, 43, 226);
+        }
     }
 
     [Export(typeof(EditorFormatDefinition))]
@@ -66,6 +79,10 @@ namespace PowerShellTools.Classification
     [Order(After = Priority.Default, Before = Priority.High)]
     internal sealed class PowerShellCommandParameterFormat : ClassificationFormatDefinition
     {
+        public PowerShellCommandParameterFormat()
+        {
+            ForegroundColor = Color.FromArgb(255, 0, 0, 128);
+        }
     }
 
     [Export(typeof(EditorFormatDefinition))]
@@ -76,6 +93,10 @@ namespace PowerShellTools.Classification
     [Order(After = Priority.Default, Before = Priority.High)]
     internal sealed class PowerShellCommentFormat : ClassificationFormatDefinition
     {
+        public PowerShellCommentFormat()
+        {
+            ForegroundColor = Color.FromArgb(255, 0, 100, 0);
+        }
     }
 
     [Export(typeof(EditorFormatDefinition))]
@@ -86,6 +107,10 @@ namespace PowerShellTools.Classification
     [Order(After = Priority.Default, Before = Priority.High)]
     internal sealed class PowerShellKeywordFormat : ClassificationFormatDefinition
     {
+        public PowerShellKeywordFormat()
+        {
+            ForegroundColor = Color.FromArgb(255, 0, 0, 139);
+        }
     }
 
     [Export(typeof(EditorFormatDefinition))]
@@ -96,6 +121,10 @@ namespace PowerShellTools.Classification
     [Order(After = Priority.Default, Before = Priority.High)]
     internal sealed class PowerShellNumberFormat : ClassificationFormatDefinition
     {
+        public PowerShellNumberFormat()
+        {
+            ForegroundColor = Color.FromArgb(255, 128, 0, 128);
+        }
     }
 
     [Export(typeof(EditorFormatDefinition))]
@@ -106,6 +135,10 @@ namespace PowerShellTools.Classification
     [Order(After = Priority.Default, Before = Priority.High)]
     internal sealed class PowerShellOperatorsFormat : ClassificationFormatDefinition
     {
+        public PowerShellOperatorsFormat()
+        {
+            ForegroundColor = Color.FromArgb(255, 169, 169, 169);
+        }
     }
 
     [Export(typeof(EditorFormatDefinition))]
@@ -116,6 +149,10 @@ namespace PowerShellTools.Classification
     [Order(After = Priority.Default, Before = Priority.High)]
     internal sealed class PowerShellStringFormat : ClassificationFormatDefinition
     {
+        public PowerShellStringFormat()
+        {
+            ForegroundColor = Color.FromArgb(255, 139, 0, 0);
+        }
     }
 
     [Export(typeof(EditorFormatDefinition))]
@@ -126,6 +163,10 @@ namespace PowerShellTools.Classification
     [Order(After = Priority.Default, Before = Priority.High)]
     internal sealed class PowerShellTypeFormat : ClassificationFormatDefinition
     {
+        public PowerShellTypeFormat()
+        {
+            ForegroundColor = Color.FromArgb(255, 0, 128, 128);
+        }
     }
 
     [Export(typeof(EditorFormatDefinition))]
@@ -136,6 +177,10 @@ namespace PowerShellTools.Classification
     [Order(After = Priority.Default, Before = Priority.High)]
     internal sealed class PowerShellVariablesFormat : ClassificationFormatDefinition
     {
+        public PowerShellVariablesFormat()
+        {
+            ForegroundColor = Color.FromArgb(255, 255, 69, 0);
+        }
     }
 
     [Export(typeof(EditorFormatDefinition))]
@@ -146,6 +191,10 @@ namespace PowerShellTools.Classification
     [Order(After = Priority.Default, Before = Priority.High)]
     internal sealed class PowerShellMemberFormat : ClassificationFormatDefinition
     {
+        public PowerShellMemberFormat()
+        {
+            ForegroundColor = Color.FromArgb(255, 0, 0, 0);
+        }
     }
 
     [Export(typeof(EditorFormatDefinition))]
@@ -156,6 +205,10 @@ namespace PowerShellTools.Classification
     [Order(After = Priority.Default, Before = Priority.High)]
     internal sealed class PowerShellGroupStartFormat: ClassificationFormatDefinition
     {
+        public PowerShellGroupStartFormat()
+        {
+            ForegroundColor = Color.FromArgb(255, 0, 0, 0);
+        }
     }
 
     [Export(typeof(EditorFormatDefinition))]
@@ -166,6 +219,10 @@ namespace PowerShellTools.Classification
     [Order(After = Priority.Default, Before = Priority.High)]
     internal sealed class PowerShellGroupEndFormat : ClassificationFormatDefinition
     {
+        public PowerShellGroupEndFormat()
+        {
+            ForegroundColor = Color.FromArgb(255, 0, 0, 0);
+        }
     }
 }
 

--- a/PowerShellTools/Classification/PowerShellClassifier.cs
+++ b/PowerShellTools/Classification/PowerShellClassifier.cs
@@ -28,7 +28,7 @@ namespace PowerShellTools.Classification
 		private static ClassificationTypeDefinition groupStartTypeDefinition;
         [BaseDefinition(PredefinedClassificationTypeNames.Keyword), Name(Classifications.PowerShellKeyword), Export(typeof(ClassificationTypeDefinition))]
 		private static ClassificationTypeDefinition keywordTypeDefinition;
-        [BaseDefinition(PredefinedClassificationTypeNames.Operator), Name(Classifications.PowerShellLineCotinuation), Export(typeof(ClassificationTypeDefinition))]
+        [BaseDefinition(PredefinedClassificationTypeNames.Operator), Name(Classifications.PowerShellLineContinuation), Export(typeof(ClassificationTypeDefinition))]
 		private static ClassificationTypeDefinition lineContinuationTypeDefinition;
         [BaseDefinition(PredefinedClassificationTypeNames.Operator), Name(Classifications.PowerShellLoopLabel), Export(typeof(ClassificationTypeDefinition))]
 		private static ClassificationTypeDefinition loopLabelTypeDefinition;
@@ -65,7 +65,7 @@ namespace PowerShellTools.Classification
             tokenClassificationTypeMap[PSTokenType.GroupEnd] = EditorImports.ClassificationTypeRegistryService.GetClassificationType(Classifications.PowerShellGroupEnd);
             tokenClassificationTypeMap[PSTokenType.GroupStart] = EditorImports.ClassificationTypeRegistryService.GetClassificationType(Classifications.PowerShellGroupStart);
             tokenClassificationTypeMap[PSTokenType.Keyword] = EditorImports.ClassificationTypeRegistryService.GetClassificationType(Classifications.PowerShellKeyword);
-            tokenClassificationTypeMap[PSTokenType.LineContinuation] = EditorImports.ClassificationTypeRegistryService.GetClassificationType(Classifications.PowerShellLineCotinuation);
+            tokenClassificationTypeMap[PSTokenType.LineContinuation] = EditorImports.ClassificationTypeRegistryService.GetClassificationType(Classifications.PowerShellLineContinuation);
             tokenClassificationTypeMap[PSTokenType.LoopLabel] = EditorImports.ClassificationTypeRegistryService.GetClassificationType(Classifications.PowerShellLoopLabel);
             tokenClassificationTypeMap[PSTokenType.Member] = EditorImports.ClassificationTypeRegistryService.GetClassificationType(Classifications.PowerShellMember);
             tokenClassificationTypeMap[PSTokenType.NewLine] = EditorImports.ClassificationTypeRegistryService.GetClassificationType(Classifications.PowerShellNewLine);


### PR DESCRIPTION
@bilalwMSFT @AndreSayreMSFT @EricMSFT @jinglou- 
