### PR TITLE
Bug fix for repl windows doesn't support IntelliSense correctly

### DIFF
--- a/PowerShellTools/Intellisense/IntelliSenseManager.cs
+++ b/PowerShellTools/Intellisense/IntelliSenseManager.cs
@@ -227,16 +227,16 @@ namespace PowerShellTools.Intellisense
                 replbuffers.Remove(currentActiveReplBuffer);
                 if (replbuffers.Count != 0)
                 {
-                    script = replbuffers.Select(b => b.CurrentSnapshot.GetText()).Aggregate((current, next) => current + next);
+                    script = replbuffers.Select(b => b.CurrentSnapshot.GetText())
+                                        .Aggregate((current, next) => current + next);
                 }                
 
                 var previousScriptLength = script.Length;
                 var caretPos = _textView.Caret.Position.BufferPosition;
-                var bufferPoint = _textView.BufferGraph.MapDownToFirstMatch(
-                    caretPos,
-                    PointTrackingMode.Positive,
-                    x => x.TextBuffer.ContentType == PowerShellToolsPackage.Instance.ContentType,
-                    PositionAffinity.Successor);
+                var bufferPoint = _textView.BufferGraph.MapDownToBuffer(caretPos,
+                                                                        PointTrackingMode.Positive,
+                                                                        currentActiveReplBuffer,
+                                                                        PositionAffinity.Successor);
                 int caretInCurrentBuffer = bufferPoint.Value.Position;
 
                 script += currentActiveReplBuffer.CurrentSnapshot.GetText(0, caretInCurrentBuffer);

--- a/PowerShellTools/Intellisense/IntelliSenseManager.cs
+++ b/PowerShellTools/Intellisense/IntelliSenseManager.cs
@@ -10,6 +10,7 @@ using log4net;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Repl;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
@@ -108,7 +109,7 @@ namespace PowerShellTools.Intellisense
                 {
                     if (_activeSession.CompletionSets[0].SelectionStatus.IsSelected)
                     {
-                      _activeSession.Commit();
+                        _activeSession.Commit();
                     }
                 }
                 else
@@ -206,12 +207,49 @@ namespace PowerShellTools.Intellisense
             int completionReplacementIndex;
             int completionReplacementLength;
 
+            // Procedures for correctly supporting IntelliSense in REPL window.
+            // Step 1, determine if this is REPL windows IntelliSense. If no, continue with normal IntelliSense triggering process. Otherwise, continue with the following steps.            
+            // Step 2, map the caret position in current text buffer to the one in current POWERSHELL text buffer adjust it if there are previous POWERSHELL text buffers.
+            // Step 3, get all text buffers of POWERSHELL, concat all the texts from previous buffers and then concat the current POWERSHELL text which only ranges from 0 to the caret position from Step 2.
+            // Step 4, get the command completion results using the script text from Step 3 and the mapped caret position from Step 2.
+            // Step 5, from this point on, make sure we go back to the original text buffer and caret position so that we can show the completion window in the right place.
+            string script = String.Empty;
+            int scriptParsePosition = 0;
+            if (_textView.TextBuffer.ContentType.TypeName.Equals(PowerShellConstants.LanguageName, StringComparison.Ordinal))
+            {
+                script = _textView.TextBuffer.CurrentSnapshot.GetText();
+                scriptParsePosition = caretPosition;
+            }
+            else if (_textView.TextBuffer.ContentType.TypeName.Equals(ReplConstants.ReplContentTypeName, StringComparison.Ordinal))
+            {
+                var replbuffers = _textView.BufferGraph.GetTextBuffers(p => p.ContentType.TypeName.Equals(PowerShellConstants.LanguageName, StringComparison.Ordinal));
+                var currentActiveReplBuffer = replbuffers.LastOrDefault();
+                replbuffers.Remove(currentActiveReplBuffer);
+                if (replbuffers.Count != 0)
+                {
+                    script = replbuffers.Select(b => b.CurrentSnapshot.GetText()).Aggregate((current, next) => current + next);
+                }                
 
-            var trackingSpan = _textView.TextBuffer.CurrentSnapshot.CreateTrackingSpan(0, _textView.TextBuffer.CurrentSnapshot.Length, SpanTrackingMode.EdgeInclusive);
-            var script = trackingSpan.GetText(_textView.TextBuffer.CurrentSnapshot);
+                var previousScriptLength = script.Length;
+                var caretPos = _textView.Caret.Position.BufferPosition;
+                var bufferPoint = _textView.BufferGraph.MapDownToFirstMatch(
+                    caretPos,
+                    PointTrackingMode.Positive,
+                    x => x.TextBuffer.ContentType == PowerShellToolsPackage.Instance.ContentType,
+                    PositionAffinity.Successor);
+                int caretInCurrentBuffer = bufferPoint.Value.Position;
+
+                script += currentActiveReplBuffer.CurrentSnapshot.GetText(0, caretInCurrentBuffer);
+                scriptParsePosition = caretInCurrentBuffer + previousScriptLength;
+            }
+            else
+            {
+                Log.Error("The content type of the text buffer isn't recognized.");
+                return;
+            }
 
             // Go out-of-proc here to get the completion list
-            var commandCompletion = PowerShellToolsPackage.IntelliSenseService.GetCompletionResults(script, caretPosition);
+            var commandCompletion = PowerShellToolsPackage.IntelliSenseService.GetCompletionResults(script, scriptParsePosition);
             if (commandCompletion == null)
             {
                 return;
@@ -221,7 +259,7 @@ namespace PowerShellTools.Intellisense
                                                                  item.ListItemText,
                                                                  (CompletionResultType)item.ResultType,
                                                                  item.ToolTip)).ToList();
-            completionReplacementIndex = commandCompletion.ReplacementIndex;
+            completionReplacementIndex = caretPosition - commandCompletion.ReplacementLength;
             completionReplacementLength = commandCompletion.ReplacementLength;
 
             var line = _textView.Caret.Position.BufferPosition.GetContainingLine();
@@ -236,7 +274,7 @@ namespace PowerShellTools.Intellisense
                     {
                         IntellisenseDone(completionMatchesList,
                                         lineStartPosition,
-                                        completionReplacementIndex + 0,
+                                        completionReplacementIndex,
                                         completionReplacementLength,
                                         caretPosition);
                     }
@@ -251,7 +289,7 @@ namespace PowerShellTools.Intellisense
             _intellisenseRunning = false;
         }
 
-        internal void IntellisenseDone(IList<CompletionResult> completionResults, int lineStartPosition, int replacementIndex, int replacementLength, int startCaretPosition)
+        private void IntellisenseDone(IList<CompletionResult> completionResults, int lineStartPosition, int replacementIndex, int replacementLength, int startCaretPosition)
         {
             var textBuffer = _textView.TextBuffer;
             var length = replacementIndex - lineStartPosition;

--- a/PowerShellTools/ServiceManagement/ConnectionManager.cs
+++ b/PowerShellTools/ServiceManagement/ConnectionManager.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using System.ServiceModel;
-using PowerShellTools.Common;
-using PowerShellTools.Common.ServiceManagement.IntelliSenseContract;
-using System.ServiceModel;
-using PowerShellTools.Common.ServiceManagement.DebuggingContract;
-using PowerShellTools.DebugEngine;
 using System.Diagnostics;
+using System.ServiceModel;
 using log4net;
+using PowerShellTools.Common;
+using PowerShellTools.Common.ServiceManagement.DebuggingContract;
+using PowerShellTools.Common.ServiceManagement.IntelliSenseContract;
+using PowerShellTools.DebugEngine;
 
 namespace PowerShellTools.ServiceManagement
 {

--- a/PowershellTools.Common/IntelliSense/CommandCompletionHelper.cs
+++ b/PowershellTools.Common/IntelliSense/CommandCompletionHelper.cs
@@ -31,10 +31,14 @@ namespace PowerShellTools.Common.IntelliSense
                 return null;
             }
 
-            var ps = PowerShell.Create();
-            ps.Runspace = runspace;
+            CommandCompletion commandCompletion;
+            using (var ps = PowerShell.Create())
+            {
+                ps.Runspace = runspace;
+                commandCompletion = CommandCompletion.CompleteInput(ast, tokens, cursorPosition, null, ps);
+            }
 
-            return CommandCompletion.CompleteInput(ast, tokens, cursorPosition, null, ps);
+            return commandCompletion;
         }
 
         /// <summary>

--- a/PowershellTools.HostService/ServiceManagement/PowershellIntelliSenseService.cs
+++ b/PowershellTools.HostService/ServiceManagement/PowershellIntelliSenseService.cs
@@ -3,6 +3,7 @@ using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
 using PowerShellTools.Common.IntelliSense;
 using PowerShellTools.Common.ServiceManagement.IntelliSenseContract;
+using PowerShellTools.HostService.ServiceManagement.Debugging;
 
 namespace PowerShellTools.HostService.ServiceManagement
 {
@@ -11,16 +12,7 @@ namespace PowerShellTools.HostService.ServiceManagement
     /// </summary>
     public sealed class PowershellIntelliSenseService : IPowershellIntelliSenseService
     {
-        private Runspace _runspace;
-
-        /// <summary>
-        /// Create and open the runspace for the sake of service.
-        /// </summary>
-        public PowershellIntelliSenseService()
-        {
-            _runspace = RunspaceFactory.CreateRunspace();
-            _runspace.Open();
-        }
+        private readonly Runspace _runspace = PowershellDebuggingService.Runspace;
 
         #region IAutoCompletionService Members
 


### PR DESCRIPTION
The root cause is all texts in REPL window is fed to IntelliSense parser which results in incorrect completion lists. To fix this, we need to pick only user input or we can say exclude all the standard inserts and output. Besides the text adjustment, we also need to adjust the caret position for both parser and VS so that first, the parser knows the right position in the newly formed text, second, VS knows where to show the completion lists.
@Microsoft/poshtools @adamdriscoll 
