### PR TITLE
Just feed the current command to IntelliSense parser

### DIFF
--- a/PowerShellTools/Intellisense/IntelliSenseManager.cs
+++ b/PowerShellTools/Intellisense/IntelliSenseManager.cs
@@ -209,8 +209,8 @@ namespace PowerShellTools.Intellisense
 
             // Procedures for correctly supporting IntelliSense in REPL window.
             // Step 1, determine if this is REPL windows IntelliSense. If no, continue with normal IntelliSense triggering process. Otherwise, continue with the following steps.            
-            // Step 2, map the caret position in current text buffer to the one in current POWERSHELL text buffer adjust it if there are previous POWERSHELL text buffers.
-            // Step 3, get all text buffers of POWERSHELL, concat all the texts from previous buffers and then concat the current POWERSHELL text which only ranges from 0 to the caret position from Step 2.
+            // Step 2, map the caret position in current REPL window text buffer to the one in current POWERSHELL text buffer.
+            // Step 3, get the current POWERSHELL text which only ranges from 0 to the caret position from Step 2.
             // Step 4, get the command completion results using the script text from Step 3 and the mapped caret position from Step 2.
             // Step 5, from this point on, make sure we go back to the original text buffer and caret position so that we can show the completion window in the right place.
             string script = String.Empty;

--- a/PowerShellTools/Intellisense/IntelliSenseManager.cs
+++ b/PowerShellTools/Intellisense/IntelliSenseManager.cs
@@ -222,25 +222,14 @@ namespace PowerShellTools.Intellisense
             }
             else if (_textView.TextBuffer.ContentType.TypeName.Equals(ReplConstants.ReplContentTypeName, StringComparison.Ordinal))
             {
-                var replbuffers = _textView.BufferGraph.GetTextBuffers(p => p.ContentType.TypeName.Equals(PowerShellConstants.LanguageName, StringComparison.Ordinal));
-                var currentActiveReplBuffer = replbuffers.LastOrDefault();
-                replbuffers.Remove(currentActiveReplBuffer);
-                if (replbuffers.Count != 0)
-                {
-                    script = replbuffers.Select(b => b.CurrentSnapshot.GetText())
-                                        .Aggregate((current, next) => current + next);
-                }                
-
-                var previousScriptLength = script.Length;
-                var caretPos = _textView.Caret.Position.BufferPosition;
-                var bufferPoint = _textView.BufferGraph.MapDownToBuffer(caretPos,
-                                                                        PointTrackingMode.Positive,
-                                                                        currentActiveReplBuffer,
-                                                                        PositionAffinity.Successor);
-                int caretInCurrentBuffer = bufferPoint.Value.Position;
-
-                script += currentActiveReplBuffer.CurrentSnapshot.GetText(0, caretInCurrentBuffer);
-                scriptParsePosition = caretInCurrentBuffer + previousScriptLength;
+                var currentActiveReplBuffer = _textView.BufferGraph.GetTextBuffers(p => p.ContentType.TypeName.Equals(PowerShellConstants.LanguageName, StringComparison.Ordinal))
+                                                                   .LastOrDefault();
+                var currentBufferPoint = _textView.BufferGraph.MapDownToBuffer(_textView.Caret.Position.BufferPosition,
+                                                                               PointTrackingMode.Positive,
+                                                                               currentActiveReplBuffer,
+                                                                               PositionAffinity.Successor);
+                scriptParsePosition = currentBufferPoint.Value.Position;
+                script = currentActiveReplBuffer.CurrentSnapshot.GetText(0, scriptParsePosition);
             }
             else
             {
@@ -259,8 +248,8 @@ namespace PowerShellTools.Intellisense
                                                                  item.ListItemText,
                                                                  (CompletionResultType)item.ResultType,
                                                                  item.ToolTip)).ToList();
-            completionReplacementIndex = caretPosition - commandCompletion.ReplacementLength;
             completionReplacementLength = commandCompletion.ReplacementLength;
+            completionReplacementIndex = caretPosition - completionReplacementLength;
 
             var line = _textView.Caret.Position.BufferPosition.GetContainingLine();
             var caretInLine = (caretPosition - line.Start);

--- a/PowerShellTools/Intellisense/IntellisenseControllerProvider.cs
+++ b/PowerShellTools/Intellisense/IntellisenseControllerProvider.cs
@@ -12,11 +12,8 @@
  *
  * ***************************************************************************/
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Linq;
-using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Shell;
@@ -24,6 +21,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.IncrementalSearch;
 using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
 
 namespace PowerShellTools.Intellisense {
@@ -74,7 +72,7 @@ namespace PowerShellTools.Intellisense {
 
         #region IVsTextViewCreationListener Members
 
-        public void VsTextViewCreated(Microsoft.VisualStudio.TextManager.Interop.IVsTextView textViewAdapter) {
+        public void VsTextViewCreated(IVsTextView textViewAdapter) {
             var textView = _adaptersFactory.GetWpfTextView(textViewAdapter);
             IntellisenseController controller;
             if (textView.Properties.TryGetProperty<IntellisenseController>(typeof(IntellisenseController), out controller)) {


### PR DESCRIPTION
With the new runspace, we don't need the previous command text as they are already cached in the runspace.
@Microsoft/poshtools 
