### PR TITLE
Brace match

### DIFF
--- a/PowerShellTools/Intellisense/BraceCompletionController.cs
+++ b/PowerShellTools/Intellisense/BraceCompletionController.cs
@@ -112,6 +112,11 @@ namespace PowerShellTools.Intellisense
                     SetBraceCompleteState(false);
                     break;
                 case (uint)VSConstants.VSStd2KCmdID.BACKSPACE:
+                    // Return in Repl windows would execute the current command 
+                    if (_textView.TextBuffer.ContentType.TypeName.Equals(ReplConstants.ReplContentTypeName, StringComparison.Ordinal))
+                    {
+                        break;
+                    }
                     if (ProcessBackspaceKey())
                     {
                         SetBraceCompleteState(false);
@@ -199,7 +204,7 @@ namespace PowerShellTools.Intellisense
 
         private bool ProcessBackspaceKey()
         {
-            if (_isLastCmdBraceComplete)
+            if (_isLastCmdBraceComplete && IsCaretInMiddleOfPairedCurlyBrace())
             {
                 _undoHistory.Undo(1);
             }

--- a/PowerShellTools/Intellisense/BraceCompletionController.cs
+++ b/PowerShellTools/Intellisense/BraceCompletionController.cs
@@ -1,0 +1,282 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Documents;
+using EnvDTE;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Repl;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace PowerShellTools.Intellisense
+{
+    /// <summary>
+    /// Command handler in the command chain that is used for complete braces for both the editor and REPL window.
+    /// </summary>
+    internal sealed class BraceCompletionController : IOleCommandTarget
+    {
+
+        private readonly ITextView _textView;
+        private readonly IEditorOperations _editorOperations;
+        private readonly ITextUndoHistory _undoHistory;
+        private readonly SVsServiceProvider _serviceProvider;
+
+        private bool _isLastCmdBraceComplete = false;
+
+        public BraceCompletionController(ITextView textView, 
+                                         IEditorOperations editorOperations, 
+                                         ITextUndoHistory undoHistory,
+                                         SVsServiceProvider serviceProvider)
+        {
+            if (textView == null)
+            {
+                throw new ArgumentNullException("textView");
+            }
+            if (editorOperations == null)
+            {
+                throw new ArgumentNullException("editorOperations");
+            }
+            if (undoHistory == null)
+            {
+                throw new ArgumentNullException("undoHistory");
+            }
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException("serviceProvider");
+            }
+
+            _textView = textView;
+            _editorOperations = editorOperations;
+            _undoHistory = undoHistory;
+            _serviceProvider = serviceProvider;
+        }
+
+        public IOleCommandTarget NextCommandHandler { get; set; }
+
+        #region IOleCommandTarget implementation
+
+        public int Exec(ref Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
+        {
+            if (VsShellUtilities.IsInAutomationFunction(_serviceProvider))
+            {
+                return NextCommandHandler.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
+            }
+
+            // pass along the command so the char is added to the buffer
+            //int execResult = NextCommandHandler.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
+            switch (nCmdID)
+            {
+                case (uint)VSConstants.VSStd2KCmdID.TYPECHAR:
+                    var typedChar = Char.MinValue;
+                    typedChar = (char)(ushort)Marshal.GetObjectForNativeVariant(pvaIn);
+                    
+                    // If we processed the typed left brace, no need to pass along the command as the char is already added to the buffer.
+                    if (IsLeftBrace(typedChar))
+                    {
+                        CompleteBrace(typedChar);
+                        SetBraceCompleteState(true);
+                        return VSConstants.S_OK;
+                    }
+                    else if (IsRightBrace(typedChar))
+                    {
+                        if (ProcessTypedRightBrace(typedChar))
+                        {
+                            // If this right brace is typed right after typing left brace,
+                            // we just move the caret to the right side of the right brace and return.
+                            // This means we will not add the typed right brace to the text buffer.
+                            SetBraceCompleteState(false);
+                            return VSConstants.S_OK;
+                        }
+                    }
+                    SetBraceCompleteState(false);
+                    break;
+                case (uint)VSConstants.VSStd2KCmdID.RETURN:
+                    // Return in Repl windows would execute the current command 
+                    if (_textView.TextBuffer.ContentType.TypeName.Equals(ReplConstants.ReplContentTypeName, StringComparison.Ordinal))
+                    {
+                        SetBraceCompleteState(false);
+                        break;
+                    }
+                    if (ProcessReturnKey())
+                    {
+                        SetBraceCompleteState(false);
+                        return VSConstants.S_OK;
+                    }
+                    SetBraceCompleteState(false);
+                    break;
+                case (uint)VSConstants.VSStd2KCmdID.BACKSPACE:
+                    if (ProcessBackspaceKey())
+                    {
+                        SetBraceCompleteState(false);
+                        return VSConstants.S_OK;
+                    }
+                    SetBraceCompleteState(false);
+                    break;
+                case (uint)VSConstants.VSStd2KCmdID.DELETE:                    
+                case (uint)VSConstants.VSStd2KCmdID.UNDO:
+                    SetBraceCompleteState(false);
+                    break;
+                default:
+                    break;
+            }
+
+            return NextCommandHandler.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
+        }
+
+        public int QueryStatus(ref Guid pguidCmdGroup, uint cCmds, OLECMD[] prgCmds, IntPtr pCmdText)
+        {
+            return NextCommandHandler.QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText);
+        }
+
+        #endregion
+        
+        /// <summary>
+        /// Complete the left brace with matched right brace
+        /// </summary>
+        /// <param name="leftBrace">The left brace to be completed.</param>
+        private void CompleteBrace(char leftBrace)
+        {
+            var typedCharToString = leftBrace.ToString();
+
+            // Step 1, create an undo transaction in case after typing the left brace user then click BACKSPACE to delete it. 
+            //         In that case, we need to undo this transaction, which will delete not only the left brace but also the filled right brace
+            // Step 2, insert the typed char which is the left brace
+            // Step 3, insert a matched right brace and then move caret to the previous char, meaning the caret ends up in the middle of the brace pair.
+            using (var undo = _undoHistory.CreateTransaction("Fill in " + typedCharToString))
+            {
+                _editorOperations.AddBeforeTextBufferChangePrimitive();
+
+                _editorOperations.InsertText(typedCharToString);
+                _editorOperations.InsertText(GetMatchedRightBrace(leftBrace).ToString());
+                _editorOperations.MoveToPreviousCharacter(false);
+
+                _editorOperations.AddAfterTextBufferChangePrimitive();
+                undo.Complete();
+            }     
+        }
+        
+        private bool ProcessTypedRightBrace(char typedChar)
+        {
+            if (_isLastCmdBraceComplete)
+            {
+                _editorOperations.MoveToNextCharacter(false);
+            }
+
+            return _isLastCmdBraceComplete;
+        }
+
+        private bool ProcessReturnKey()
+        {
+            bool isReturnKeyProcessed = IsCaretInMiddleOfPairedCurlyBrace();
+            if (isReturnKeyProcessed)
+            {
+                using (var undo = _undoHistory.CreateTransaction("Insert new line."))
+                {
+                    _editorOperations.AddBeforeTextBufferChangePrimitive();
+
+                    DeleteRightBrace();
+                    _editorOperations.InsertNewLine();
+                    _editorOperations.InsertText('}'.ToString());
+                    _editorOperations.MoveLineUp(false);
+                    _editorOperations.MoveToEndOfLine(false);
+                    _editorOperations.InsertNewLine();
+                    _editorOperations.Indent();
+
+                    _editorOperations.AddAfterTextBufferChangePrimitive();
+                    undo.Complete();
+                }
+            }
+
+            return isReturnKeyProcessed;
+        }
+
+        private bool ProcessBackspaceKey()
+        {
+            if (_isLastCmdBraceComplete)
+            {
+                _undoHistory.Undo(1);
+            }
+            return _isLastCmdBraceComplete;
+        }
+    
+        private void SetBraceCompleteState(bool isBraceComplete)
+        {
+            _isLastCmdBraceComplete = isBraceComplete;
+        }
+        
+        private bool IsCaretInMiddleOfPairedCurlyBrace()
+        {
+            int currentCaret = _textView.Caret.Position.BufferPosition.Position;
+            return IsPreviousCharLeftCurlyBrace(currentCaret) && IsNextCharRightCurlyBrace(currentCaret);
+        }
+    
+        private bool IsPreviousCharLeftCurlyBrace(int currentCaret)
+        {
+            if (currentCaret == 0) return false;
+
+            ITrackingPoint previousCharPosition = _textView.TextSnapshot.CreateTrackingPoint(currentCaret - 1, PointTrackingMode.Positive);
+            char previousChar = previousCharPosition.GetCharacter(_textView.TextSnapshot);
+            return IsLeftCurlyBrace(previousChar);
+        }
+
+        private bool IsNextCharRightCurlyBrace(int currentCaret)
+        {
+            if (currentCaret >= _textView.TextSnapshot.Length) return false;
+
+            ITrackingPoint previousCharPosition = _textView.TextSnapshot.CreateTrackingPoint(currentCaret, PointTrackingMode.Positive);
+            char nextChar = previousCharPosition.GetCharacter(_textView.TextSnapshot);
+            return IsRightCurlyBrace(nextChar);
+        }
+
+        private void DeleteRightBrace()
+        {
+            using (var undo = _undoHistory.CreateTransaction("Delete right brace."))
+            {
+                _editorOperations.AddBeforeTextBufferChangePrimitive();
+
+                _editorOperations.Delete();
+
+                _editorOperations.AddAfterTextBufferChangePrimitive();
+                undo.Complete();
+            }
+        }
+
+        private static bool IsLeftBrace(char ch)
+        {
+            return IsLeftCurlyBrace(ch) || ch == '[' || ch == '(';
+        }
+
+        private static bool IsRightBrace(char ch)
+        {
+            return IsRightCurlyBrace(ch) || ch == ']' || ch == ')';
+        }
+
+        private static bool IsLeftCurlyBrace(char ch)
+        {
+            return ch == '{';
+        }
+
+        private static bool IsRightCurlyBrace(char ch)
+        {
+            return ch == '}';
+        }
+
+        private static char GetMatchedRightBrace(char ch)
+        {
+            switch (ch)
+            {
+                case '{': return '}';
+                case '[': return ']';
+                case '(': return ')';
+                default: throw new InvalidOperationException("The character is unrecognized.");
+            }
+        }
+    }
+}

--- a/PowerShellTools/Intellisense/IntelliSenseManager.cs
+++ b/PowerShellTools/Intellisense/IntelliSenseManager.cs
@@ -65,7 +65,7 @@ namespace PowerShellTools.Intellisense
             }
             //make a copy of this so we can look at it after forwarding some commands 
             var commandId = nCmdId;
-            var typedChar = char.MinValue;
+            var typedChar = Char.MinValue;
             //make sure the input is a char before getting it 
             if (pguidCmdGroup == VSConstants.VSStd2K && nCmdId == (uint)VSConstants.VSStd2KCmdID.TYPECHAR)
             {
@@ -122,11 +122,11 @@ namespace PowerShellTools.Intellisense
             //pass along the command so the char is added to the buffer 
             int retVal = NextCommandHandler.Exec(ref pguidCmdGroup, nCmdId, nCmdexecopt, pvaIn, pvaOut);
             bool handled = false;
-            if (!typedChar.Equals(char.MinValue) && IsIntellisenseTrigger(typedChar))
+            if (!typedChar.Equals(Char.MinValue) && IsIntellisenseTrigger(typedChar))
             {
                 TriggerCompletion();
             }
-            if (!typedChar.Equals(char.MinValue) && IsFilterTrigger(typedChar))
+            if (!typedChar.Equals(Char.MinValue) && IsFilterTrigger(typedChar))
             {
                 if (_activeSession != null)
                 {
@@ -164,7 +164,7 @@ namespace PowerShellTools.Intellisense
             }
             if (handled) return VSConstants.S_OK;
             return retVal;
-        }
+        }        
 
         /// <summary>
         /// Triggers an IntelliSense session. This is done in a seperate thread than the UI to allow
@@ -329,7 +329,7 @@ namespace PowerShellTools.Intellisense
             _activeSession = null;
         }
 
-        internal static bool SpanArgumentsAreValid(ITextSnapshot snapshot, int start, int length)
+        private static bool SpanArgumentsAreValid(ITextSnapshot snapshot, int start, int length)
         {
             return start >= 0 && length >= 0 && start + length <= snapshot.Length;
         }
@@ -337,8 +337,8 @@ namespace PowerShellTools.Intellisense
         /// <summary>
         /// Determines whether a typed character should cause the completion source list to filter.
         /// </summary>
-        /// <param name="ch"></param>
-        /// <returns></returns>
+        /// <param name="ch">The typed character.</param>
+        /// <returns>True if it is a filtering character.</returns>
         private static bool IsFilterTrigger(char ch)
         {
             Log.DebugFormat("IsFilterTrigger: [{0}]", ch);
@@ -348,12 +348,12 @@ namespace PowerShellTools.Intellisense
         /// <summary>
         /// Determines whether a typed character should cause the manager to trigger the intellisense drop down.
         /// </summary>
-        /// <param name="ch"></param>
-        /// <returns></returns>
+        /// <param name="ch">The typed character.</param>
+        /// <returns>True if it is a triggering character.</returns>
         private static bool IsIntellisenseTrigger(char ch)
         {
             Log.DebugFormat("IsIntellisenseTrigger: [{0}]", ch);
             return ch == '-' || ch == '$' || ch == '.' || ch == ':' || ch == '\\';
-        }
+        }        
     }
 }

--- a/PowerShellTools/Intellisense/IntellisenseController.cs
+++ b/PowerShellTools/Intellisense/IntellisenseController.cs
@@ -19,41 +19,103 @@ using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudioTools;
 
-namespace PowerShellTools.Intellisense {
+namespace PowerShellTools.Intellisense
+{
 
-    internal sealed class IntellisenseController : IIntellisenseController, IOleCommandTarget {
+    internal sealed class IntellisenseController : IIntellisenseController, IOleCommandTarget
+    {
         private readonly ITextView _textView;
         private readonly IntellisenseControllerProvider _provider;
         private readonly IntelliSenseManager _intelliSenseManager;
-
+        private readonly BraceCompletionController _braceCompletionController;
 
         /// <summary>
         /// Attaches events for invoking Statement completion 
         /// </summary>
-        public IntellisenseController(IntellisenseControllerProvider provider, ITextView textView) {
+        public IntellisenseController(IntellisenseControllerProvider provider, ITextView textView)
+        {
             _textView = textView;
             _provider = provider;
             textView.Properties.AddProperty(typeof(IntellisenseController), this);  // added so our key processors can get back to us
 
-            _intelliSenseManager = new IntelliSenseManager(provider._CompletionBroker, provider.ServiceProvider, null, textView);
+            IEditorOperations editorOperations = provider.EditOperationsFactory.GetEditorOperations(textView);            
+			ITextUndoHistory undoHistory = provider.UndoHistoryRegistry.GetHistory(textView.TextBuffer);
+
+            _intelliSenseManager = new IntelliSenseManager(provider.CompletionBroker, provider.ServiceProvider, null, textView);
+            _braceCompletionController = new BraceCompletionController(textView, editorOperations, undoHistory, provider.ServiceProvider);
+
         }
 
-        public void ConnectSubjectBuffer(ITextBuffer subjectBuffer) {
+        public ICompletionBroker CompletionBroker
+        {
+            get
+            {
+                return _provider.CompletionBroker;
+            }
         }
 
-        public void DisconnectSubjectBuffer(ITextBuffer subjectBuffer) {
+        public IVsEditorAdaptersFactoryService AdaptersFactory
+        {
+            get
+            {
+                return _provider.AdaptersFactory;
+            }
+        }
+
+        public ISignatureHelpBroker SignatureBroker
+        {
+            get
+            {
+                return _provider.SigBroker;
+            }
+        }
+
+        // we need this because VS won't give us certain keyboard events as they're handled before our key processor.  These
+        // include enter and tab both of which we want to complete.
+        public void AttachKeyboardFilter()
+        {
+            if (_intelliSenseManager.NextCommandHandler == null)
+            {
+                var viewAdapter = AdaptersFactory.GetViewAdapter(_textView);
+                if (viewAdapter != null)
+                {
+                    IOleCommandTarget next;
+
+                    ErrorHandler.ThrowOnFailure(viewAdapter.AddCommandFilter(this, out next));
+                    _intelliSenseManager.NextCommandHandler = next;
+
+                    ErrorHandler.ThrowOnFailure(viewAdapter.AddCommandFilter(_braceCompletionController, out next));
+                    _braceCompletionController.NextCommandHandler = next;
+                }
+            }
+        }
+
+        #region IIntellisenseController implementation
+
+        public void ConnectSubjectBuffer(ITextBuffer subjectBuffer)
+        {
+        }
+
+        public void DisconnectSubjectBuffer(ITextBuffer subjectBuffer)
+        {
         }
 
         /// <summary>
         /// Detaches the events
         /// </summary>
-        /// <param name="textView"></param>
-        public void Detach(ITextView textView) {
-            if (_textView == null) {
+        /// <param name="textView">The text view to detach from.</param>
+        public void Detach(ITextView textView)
+        {
+            if (_textView == null)
+            {
                 throw new InvalidOperationException("Already detached from text view");
             }
-            if (textView != _textView) {
+            if (textView != _textView)
+            {
                 throw new ArgumentException("Not attached to specified text view", "textView");
             }
             _textView.Properties.RemoveProperty(typeof(IntellisenseController));
@@ -61,55 +123,49 @@ namespace PowerShellTools.Intellisense {
             DetachKeyboardFilter();
         }
 
-        internal ICompletionBroker CompletionBroker {
-            get {
-                return _provider._CompletionBroker;
-            }
-        }
+        #endregion
 
-        internal IVsEditorAdaptersFactoryService AdaptersFactory {
-            get {
-                return _provider._adaptersFactory;
-            }
-        }
-
-        internal ISignatureHelpBroker SignatureBroker {
-            get {
-                return _provider._SigBroker;
-            }
-        }
-
-        // we need this because VS won't give us certain keyboard events as they're handled before our key processor.  These
-        // include enter and tab both of which we want to complete.
-
-        internal void AttachKeyboardFilter() {
-            if (_intelliSenseManager.NextCommandHandler == null) {
-                var viewAdapter = AdaptersFactory.GetViewAdapter(_textView);
-                if (viewAdapter != null)
-                {
-                    IOleCommandTarget oldTarget;
-                    ErrorHandler.ThrowOnFailure(viewAdapter.AddCommandFilter(this, out oldTarget));
-                    _intelliSenseManager.NextCommandHandler = oldTarget;
-                }
-            }
-        }
-
-        private void DetachKeyboardFilter() {
-            if (_intelliSenseManager.NextCommandHandler != null)
-            {
-                ErrorHandler.ThrowOnFailure(AdaptersFactory.GetViewAdapter(_textView).RemoveCommandFilter(this));
-                _intelliSenseManager.NextCommandHandler = null;
-            }
-        }
+        #region IOleCommandTarget implementation
 
         public int QueryStatus(ref Guid pguidCmdGroup, uint cCmds, OLECMD[] prgCmds, IntPtr pCmdText)
         {
+            if (pguidCmdGroup == CommonConstants.Std2KCmdGroupGuid)
+            {
+                for (int i = 0; i < cCmds; i++)
+                {
+                    switch ((VSConstants.VSStd2KCmdID)prgCmds[i].cmdID)
+                    {
+                        case VSConstants.VSStd2KCmdID.COMPLETEWORD:
+                            prgCmds[i].cmdf = (uint)(OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED);
+                            return VSConstants.S_OK;
+                    }
+                }
+            }
+
             return _intelliSenseManager.QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText);
         }
 
         public int Exec(ref Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
         {
             return _intelliSenseManager.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
+        }
+
+        #endregion
+        
+        private void DetachKeyboardFilter()
+        {
+            var viewAdapter = AdaptersFactory.GetViewAdapter(_textView);
+            if (_braceCompletionController.NextCommandHandler != null)
+            {
+                ErrorHandler.ThrowOnFailure(viewAdapter.RemoveCommandFilter(_braceCompletionController));
+                _braceCompletionController.NextCommandHandler = null;
+            }
+
+            if (_intelliSenseManager.NextCommandHandler != null)
+            {
+                ErrorHandler.ThrowOnFailure(viewAdapter.RemoveCommandFilter(this));
+                _intelliSenseManager.NextCommandHandler = null;
+            }
         }
     }
 }

--- a/PowerShellTools/Intellisense/IntellisenseControllerProvider.cs
+++ b/PowerShellTools/Intellisense/IntellisenseControllerProvider.cs
@@ -24,27 +24,40 @@ using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
 
-namespace PowerShellTools.Intellisense {
+namespace PowerShellTools.Intellisense
+{
     [Export(typeof(IIntellisenseControllerProvider)), ContentType(PowerShellConstants.LanguageName), Order]
-    class IntellisenseControllerProvider : IIntellisenseControllerProvider {
+    internal class IntellisenseControllerProvider : IIntellisenseControllerProvider
+    {
         [Import]
-        internal ICompletionBroker _CompletionBroker = null; // Set via MEF
-        [Import]
-        internal IEditorOperationsFactoryService _EditOperationsFactory = null; // Set via MEF
-        [Import]
-        internal IVsEditorAdaptersFactoryService _adaptersFactory { get; set; }
-        [Import]
-        internal ISignatureHelpBroker _SigBroker = null; // Set via MEF
-        [Import]
-        internal IQuickInfoBroker _QuickInfoBroker = null; // Set via MEF
-        [Import]
-        internal IIncrementalSearchFactoryService _IncrementalSearch = null; // Set via MEF
-        [Import]
-        internal SVsServiceProvider ServiceProvider { get; set; }
+        public ICompletionBroker CompletionBroker = null; // Set via MEF
 
-        public IIntellisenseController TryCreateIntellisenseController(ITextView textView, IList<ITextBuffer> subjectBuffers) {
+        [Import]
+        public IEditorOperationsFactoryService EditOperationsFactory = null; // Set via MEF
+        
+        [Import]
+        public IVsEditorAdaptersFactoryService AdaptersFactory { get; set; }
+        
+        [Import]
+        public ISignatureHelpBroker SigBroker = null; // Set via MEF
+        
+        [Import]
+        public IQuickInfoBroker QuickInfoBroker = null; // Set via MEF
+        
+        [Import]
+        public IIncrementalSearchFactoryService IncrementalSearch = null; // Set via MEF
+        
+        [Import]
+        public SVsServiceProvider ServiceProvider { get; set; }
+        
+        [Import]
+        public ITextUndoHistoryRegistry UndoHistoryRegistry = null;
+
+        public IIntellisenseController TryCreateIntellisenseController(ITextView textView, IList<ITextBuffer> subjectBuffers)
+        {
             IntellisenseController controller;
-            if (!textView.Properties.TryGetProperty<IntellisenseController>(typeof(IntellisenseController), out controller)) {
+            if (!textView.Properties.TryGetProperty<IntellisenseController>(typeof(IntellisenseController), out controller))
+            {
                 controller = new IntellisenseController(this, textView);
                 controller.AttachKeyboardFilter();
             }
@@ -62,20 +75,24 @@ namespace PowerShellTools.Intellisense {
     [Export(typeof(IVsTextViewCreationListener))]
     [ContentType("text")]
     [TextViewRole(PredefinedTextViewRoles.Editable)]
-    class TextViewCreationListener : IVsTextViewCreationListener {
-        internal readonly IVsEditorAdaptersFactoryService _adaptersFactory;
+    internal class TextViewCreationListener : IVsTextViewCreationListener
+    {
+        private readonly IVsEditorAdaptersFactoryService _adaptersFactory;
 
         [ImportingConstructor]
-        public TextViewCreationListener(IVsEditorAdaptersFactoryService adaptersFactory) {
+        public TextViewCreationListener(IVsEditorAdaptersFactoryService adaptersFactory)
+        {
             _adaptersFactory = adaptersFactory;
         }
 
         #region IVsTextViewCreationListener Members
 
-        public void VsTextViewCreated(IVsTextView textViewAdapter) {
+        public void VsTextViewCreated(IVsTextView textViewAdapter)
+        {
             var textView = _adaptersFactory.GetWpfTextView(textViewAdapter);
             IntellisenseController controller;
-            if (textView.Properties.TryGetProperty<IntellisenseController>(typeof(IntellisenseController), out controller)) {
+            if (textView.Properties.TryGetProperty<IntellisenseController>(typeof(IntellisenseController), out controller))
+            {
                 controller.AttachKeyboardFilter();
             }
         }

--- a/PowerShellTools/LanguageService/CodeWindowManager.cs
+++ b/PowerShellTools/LanguageService/CodeWindowManager.cs
@@ -50,11 +50,11 @@ namespace PowerShellTools.LanguageService
             var factory = model.GetService<IEditorOperationsFactoryService>();
 
             EditFilter editFilter = _filter = new EditFilter(textView, factory.GetEditorOperations(textView));
-            var adapter = adaptersFactory.GetViewAdapter(textView);
-            editFilter.AttachKeyboardFilter(adapter);
+            var textViewAdapter = adaptersFactory.GetViewAdapter(textView);
+            editFilter.AttachKeyboardFilter(textViewAdapter);
 
             var viewFilter = new TextViewFilter();
-            viewFilter.AttachFilter(adapter);
+            viewFilter.AttachFilter(textViewAdapter);
         }
 
         private static void OnIdle(object sender, ComponentManagerEventArgs e)

--- a/PowerShellTools/LanguageService/EditFilter.cs
+++ b/PowerShellTools/LanguageService/EditFilter.cs
@@ -43,8 +43,6 @@ namespace PowerShellTools.LanguageService
                         case VSConstants.VSStd2KCmdID.COMMENTBLOCK:
                         case VSConstants.VSStd2KCmdID.UNCOMMENT_BLOCK:
                         case VSConstants.VSStd2KCmdID.UNCOMMENTBLOCK:
-                        case VSConstants.VSStd2KCmdID.COMPLETEWORD:
-                            prgCmds[i].cmdf = (uint)(OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED);
                             return VSConstants.S_OK;
                     }
                 }

--- a/PowerShellTools/LanguageService/TextViewFilter.cs
+++ b/PowerShellTools/LanguageService/TextViewFilter.cs
@@ -16,6 +16,7 @@ using System;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudioTools;
 
 namespace Microsoft.PythonTools.Language
 {
@@ -72,7 +73,7 @@ namespace Microsoft.PythonTools.Language
                             return VSConstants.S_OK;
                     }
                 }
-            }
+            }            
 
             return _next.QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText);
         }

--- a/PowerShellTools/PowerShellTools.csproj
+++ b/PowerShellTools/PowerShellTools.csproj
@@ -261,6 +261,7 @@
     <Compile Include="GeneralDialogPage.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Intellisense\BraceCompletionController.cs" />
     <Compile Include="Intellisense\IntellisenseController.cs" />
     <Compile Include="Intellisense\IntellisenseControllerProvider.cs" />
     <Compile Include="Intellisense\IntelliSenseManager.cs" />
@@ -272,7 +273,7 @@
     <Compile Include="LanguageService\Indenter.cs" />
     <Compile Include="LanguageService\PowerShellLanguageInfo.cs" />
     <Compile Include="LanguageService\TextViewFilter.cs" />
-    <Compile Include="LanguageService\ViewFilter.cs" />
+    <Compile Include="LanguageService\EditFilter.cs" />
     <Compile Include="Guids.cs" />
     <Compile Include="Classification\OutputPaneClassifier.cs" />
     <Compile Include="PackageProperties.cs" />


### PR DESCRIPTION
Supported functions:
1. Fill the corresponding right one for typed left brace ('{', '[', '(')
2. After right brace is auto-filled, if no other cmd such as typing/return/delete/undo occurs, then Backspace will  delete both typed left brace and auto-filled right brace.
3. If the cursor is in the middle of a pair of curly braces, pressing Return will get user a new line and the curer will stay at an indent position.
4. 2 and 3 is not applicable to REPL window for its special properties.

@Microsoft/poshtools   
