### PR TITLE
Bugfix for #138 Intellisense completion will remove starting bracket

### DIFF
--- a/PowerShellTools/Intellisense/BraceCompletionController.cs
+++ b/PowerShellTools/Intellisense/BraceCompletionController.cs
@@ -156,7 +156,7 @@ namespace PowerShellTools.Intellisense
             return IsInCommentArea(caretPosition, _textView.TextBuffer);
         }
 
-        public bool IsInCommentArea(int caretPosition, ITextBuffer textBuffer)
+        internal bool IsInCommentArea(int caretPosition, ITextBuffer textBuffer)
         {
             Token[] pstokens;
             if (textBuffer.Properties.TryGetProperty<Token[]>(BufferProperties.Tokens, out pstokens))

--- a/PowerShellTools/Intellisense/PowerShellCompletionSource.cs
+++ b/PowerShellTools/Intellisense/PowerShellCompletionSource.cs
@@ -98,7 +98,27 @@ namespace PowerShellTools.Intellisense
 
     internal class PowerShellCompletionSet : CompletionSet
     {
-        private readonly FilteredObservableCollection<Completion> completions;
+        private readonly FilteredObservableCollection<Completion> completions;        
+
+        internal PowerShellCompletionSet(string moniker, 
+                                         string displayName, 
+                                         ITrackingSpan applicableTo, 
+                                         IEnumerable<Completion> completions, 
+                                         IEnumerable<Completion> completionBuilders, 
+                                         ITrackingSpan filterSpan, 
+                                         ITrackingSpan lineStartToApplicableTo)
+                : base(moniker, displayName, applicableTo, completions, completionBuilders)
+        {
+            if (filterSpan == null)
+            {
+                throw new ArgumentNullException("filterSpan");
+            }
+            this.completions = new FilteredObservableCollection<Completion>(new ObservableCollection<Completion>(completions));
+            FilterSpan = filterSpan;
+            LineStartToApplicableTo = lineStartToApplicableTo;
+            InitialApplicableTo = applicableTo.GetText(applicableTo.TextBuffer.CurrentSnapshot);
+        }
+
         public override IList<Completion> Completions
         {
             get
@@ -113,18 +133,6 @@ namespace PowerShellTools.Intellisense
 
         internal string InitialApplicableTo { get; private set; }
 
-        internal PowerShellCompletionSet(string moniker, string displayName, ITrackingSpan applicableTo, IEnumerable<Completion> completions, IEnumerable<Completion> completionBuilders, ITrackingSpan filterSpan, ITrackingSpan lineStartToApplicableTo)
-            : base(moniker, displayName, applicableTo, completions, completionBuilders)
-        {
-            if (filterSpan == null)
-            {
-                throw new ArgumentNullException("filterSpan");
-            }
-            this.completions = new FilteredObservableCollection<Completion>(new ObservableCollection<Completion>(completions));
-            FilterSpan = filterSpan;
-            LineStartToApplicableTo = lineStartToApplicableTo;
-            InitialApplicableTo = applicableTo.GetText(applicableTo.TextBuffer.CurrentSnapshot);
-        }
         public override void Filter()
         {
             var filterText = FilterSpan.GetText(FilterSpan.TextBuffer.CurrentSnapshot);
@@ -139,6 +147,7 @@ namespace PowerShellTools.Intellisense
                 completions.Filter(predicate);
             }
         }
+
         public override void SelectBestMatch()
         {
             var text = FilterSpan.GetText(FilterSpan.TextBuffer.CurrentSnapshot);


### PR DESCRIPTION
Bugfix for #138 
This commit fixes the issue IntelliSense completion will move one character backward. However, due to the way Powershell provides completion sets within double/single quotes(The completion itself contains quotes), typing with completion lists shown up will not filter the completion list. I saw ISE also has this issue. We can certainly find some magic workarounds but for now I'll log a bug and let it as it is, as I don't even think we should provide Intellisense within quotes.
@EricMSFT @AndreSayreMSFT @jinglou- 
