### PR TITLE
Bugfix for #205 IntelliSense is broken when using Backspace

### DIFF
--- a/PowerShellTools/Intellisense/IntelliSenseManager.cs
+++ b/PowerShellTools/Intellisense/IntelliSenseManager.cs
@@ -212,7 +212,6 @@ namespace PowerShellTools.Intellisense
         {
             if (_intellisenseRunning)
             {
-                Debug.Print("_intelliSenseRunning = {0}", _intellisenseRunning);
                 return;
             } 
 


### PR DESCRIPTION
Make it same as ISE behavior for Backspace when IntelliSense session is on. When we delete the triggering character, the IntelliSense session will get dismissed. 
@AndreSayreMSFT @EricMSFT @Microsoft/poshtools 
