### PR TITLE
Fixing bug 204:

### DIFF
--- a/PowerShellTools/PowerShellTools.vsct
+++ b/PowerShellTools/PowerShellTools.vsct
@@ -7,6 +7,7 @@
   <KeyBindings>
     <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidExecuteAsScript" editor="guidVSStd97" key1="VK_F5" mod1="Alt Shift"/>
     <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidExecuteSelection" editor="guidVSStd97" key1="VK_F8" mod1="Control"/>
+    <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidReplWindow" editor="guidVSStd97" key1="P" mod1="Control Shift"/>
   </KeyBindings>
 
   <!--The Commands section is where we the commands, menus and menu groups are defined.
@@ -42,7 +43,7 @@
         <Strings>
           <LocCanonicalName>PowerShell.ExecuteAsScript</LocCanonicalName>
           <CanonicalName>PowerShell.ExecuteAsScript</CanonicalName>
-          <ButtonText>Execute as script</ButtonText>
+          <ButtonText>Execute as Script</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidPoshToolsCmdSet" id="cmdidExecuteAsScriptSolution"
@@ -53,7 +54,7 @@
         <Strings>
           <LocCanonicalName>PowerShell.ExecuteAsScript</LocCanonicalName>
           <CanonicalName>PowerShell.ExecuteAsScript</CanonicalName>
-          <ButtonText>Execute as script</ButtonText>
+          <ButtonText>Execute as Script</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidPoshToolsCmdSet" id="cmdidExecuteSelection"
@@ -64,7 +65,7 @@
         <Strings>
           <LocCanonicalName>PowerShell.ExecuteSelection</LocCanonicalName>
           <CanonicalName>PowerShell.ExecuteSelection</CanonicalName>
-          <ButtonText>Execute selection</ButtonText>
+          <ButtonText>Execute Selection</ButtonText>
         </Strings>
       </Button>
       <!-- DISABLED AS CURRENTLY NOT FUNCTIONING
@@ -88,7 +89,7 @@
         <Strings>
           <LocCanonicalName>PowerShell.GotoDefinition</LocCanonicalName>
           <CanonicalName>PowerShell.GotoDefinition</CanonicalName>
-          <ButtonText>Go to definition</ButtonText>
+          <ButtonText>Go to Definition</ButtonText>
         </Strings>
       </Button>-->
       <Button guid="guidPoshToolsCmdSet" id="cmdidSnippet"
@@ -99,7 +100,7 @@
         <Strings>
           <LocCanonicalName>PowerShell.Snippet</LocCanonicalName>
           <CanonicalName>PowerShell.Snippet</CanonicalName>
-          <ButtonText>Insert snippet</ButtonText>
+          <ButtonText>Insert Snippet</ButtonText>
         </Strings>
       </Button>
 
@@ -110,7 +111,7 @@
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
           <CommandName>cmdidReplWindow</CommandName>
-          <ButtonText>PowerShell Debug Interactive</ButtonText>
+          <ButtonText>PowerShell Interactive Window</ButtonText>
         </Strings>
       </Button>
     </Buttons>


### PR DESCRIPTION
```
- Capitalized "Execute as script" to "Execute as Script"
- Capitalized "Execute selection" to "Execute Selection"
- Capitalized "Go to definition" to "Go to Definition"
- Capitalized "Insert snippet" to "Insert Snippet"
```

Fixing bug 90:
    - Changed "Powershell Debug Interactive" to "Powershell Interactive Window"
    - Added accelerator "Ctrl+Shft+P"
