### PR TITLE
Bugfix for quotes

### DIFF
--- a/PowerShellTools/Intellisense/AutoCompletionController.cs
+++ b/PowerShellTools/Intellisense/AutoCompletionController.cs
@@ -97,7 +97,7 @@ namespace PowerShellTools.Intellisense
                     // If we processed the typed left brace/quotes, no need to pass along the command as the char is already added to the buffer.
                     if (IsQuotes(typedChar))
                     {
-                        if (_isLastCmdAutoComplete && IsPreviousCharMatchedQuotes(typedChar))
+                        if (_isLastCmdAutoComplete && IsTypeCharEqualsNextChar(typedChar))
                         {
                             ProcessTypedRightBraceOrQuotes(typedChar);
                             SetAutoCompleteState(false);
@@ -273,6 +273,7 @@ namespace PowerShellTools.Intellisense
         private void SetAutoCompleteState(bool isAutoComplete)
         {
             _isLastCmdAutoComplete = isAutoComplete;
+            
         }
 
         private bool IsCaretInMiddleOfPairedBraceOrQuotes()
@@ -290,20 +291,22 @@ namespace PowerShellTools.Intellisense
             return IsLeftBraceOrQuotes(previousChar);
         }
 
-        private bool IsPreviousCharMatchedQuotes(char currentChar)
+        private bool IsTypeCharEqualsNextChar(char currentChar)
         {
             int currentCaret = _textView.Caret.Position.BufferPosition.Position;
-            ITrackingPoint previousCharPosition = _textView.TextSnapshot.CreateTrackingPoint(currentCaret - 1, PointTrackingMode.Positive);
-            char previousChar = previousCharPosition.GetCharacter(_textView.TextSnapshot);
-            return currentChar == previousChar;
+            if (currentCaret >= _textView.TextSnapshot.Length) return false;
+
+            ITrackingPoint nextCharPosition = _textView.TextSnapshot.CreateTrackingPoint(currentCaret, PointTrackingMode.Positive);
+            char nextChar = nextCharPosition.GetCharacter(_textView.TextSnapshot);
+            return currentChar == nextChar;
         }
 
         private bool IsNextCharRightBraceOrQuotes(int currentCaret)
         {
             if (currentCaret >= _textView.TextSnapshot.Length) return false;
 
-            ITrackingPoint previousCharPosition = _textView.TextSnapshot.CreateTrackingPoint(currentCaret, PointTrackingMode.Positive);
-            char nextChar = previousCharPosition.GetCharacter(_textView.TextSnapshot);
+            ITrackingPoint nextCharPosition = _textView.TextSnapshot.CreateTrackingPoint(currentCaret, PointTrackingMode.Positive);
+            char nextChar = nextCharPosition.GetCharacter(_textView.TextSnapshot);
             return IsRightBraceOrQuotes(nextChar);
         }
 

--- a/PowerShellTools/Intellisense/AutoCompletionController.cs
+++ b/PowerShellTools/Intellisense/AutoCompletionController.cs
@@ -97,7 +97,7 @@ namespace PowerShellTools.Intellisense
                     // If we processed the typed left brace/quotes, no need to pass along the command as the char is already added to the buffer.
                     if (IsQuotes(typedChar))
                     {
-                        if (_isLastCmdAutoComplete && IsTypeCharEqualsNextChar(typedChar))
+                        if (_isLastCmdAutoComplete && IsTypedCharEqualsNextChar(typedChar))
                         {
                             ProcessTypedRightBraceOrQuotes(typedChar);
                             SetAutoCompleteState(false);
@@ -291,7 +291,7 @@ namespace PowerShellTools.Intellisense
             return IsLeftBraceOrQuotes(previousChar);
         }
 
-        private bool IsTypeCharEqualsNextChar(char currentChar)
+        private bool IsTypedCharEqualsNextChar(char currentChar)
         {
             int currentCaret = _textView.Caret.Position.BufferPosition.Position;
             if (currentCaret >= _textView.TextSnapshot.Length) return false;

--- a/PowerShellTools/Intellisense/AutoCompletionController.cs
+++ b/PowerShellTools/Intellisense/AutoCompletionController.cs
@@ -97,7 +97,7 @@ namespace PowerShellTools.Intellisense
                     // If we processed the typed left brace/quotes, no need to pass along the command as the char is already added to the buffer.
                     if (IsQuotes(typedChar))
                     {
-                        if (_isLastCmdAutoComplete && IsPreviousCharMachedQuotes(typedChar))
+                        if (_isLastCmdAutoComplete && IsPreviousCharMatchedQuotes(typedChar))
                         {
                             ProcessTypedRightBraceOrQuotes(typedChar);
                             SetAutoCompleteState(false);
@@ -290,7 +290,7 @@ namespace PowerShellTools.Intellisense
             return IsLeftBraceOrQuotes(previousChar);
         }
 
-        private bool IsPreviousCharMachedQuotes(char currentChar)
+        private bool IsPreviousCharMatchedQuotes(char currentChar)
         {
             int currentCaret = _textView.Caret.Position.BufferPosition.Position;
             ITrackingPoint previousCharPosition = _textView.TextSnapshot.CreateTrackingPoint(currentCaret - 1, PointTrackingMode.Positive);

--- a/PowerShellTools/Intellisense/AutoCompletionController.cs
+++ b/PowerShellTools/Intellisense/AutoCompletionController.cs
@@ -82,7 +82,7 @@ namespace PowerShellTools.Intellisense
 
         private int ProcessKeystroke(uint nCmdID, IntPtr pvaIn)
         {            
-            if (!_textView.Selection.IsEmpty)
+            if (!_textView.Selection.IsEmpty || IsInCommentArea())
             {
                 // Auto completion won't take effect when there is text selection.
                 return VSConstants.S_FALSE;
@@ -94,8 +94,8 @@ namespace PowerShellTools.Intellisense
                     var typedChar = Char.MinValue;
                     typedChar = (char)(ushort)Marshal.GetObjectForNativeVariant(pvaIn);
 
-                    // If we processed the typed left brace, no need to pass along the command as the char is already added to the buffer.
-                    if (IsQuotes(typedChar) && !IsInCommentArea())
+                    // If we processed the typed left brace/quotes, no need to pass along the command as the char is already added to the buffer.
+                    if (IsQuotes(typedChar))
                     {
                         if (_isLastCmdAutoComplete && IsPreviousCharMachedQuotes(typedChar))
                         {
@@ -111,7 +111,7 @@ namespace PowerShellTools.Intellisense
                         }
                     }
 
-                    if (IsLeftBraceOrQuotes(typedChar) && !IsInCommentArea())
+                    if (IsLeftBraceOrQuotes(typedChar))
                     {
                         CompleteBraceOrQuotes(typedChar);
                         SetAutoCompleteState(true);


### PR DESCRIPTION
Fix the issue that typing a quotes right after another don't just move the cursor forward.
@AndreSayreMSFT @EricMSFT @Microsoft/poshtools 
