### PR TITLE
Bug Fix #174: "Add-AzureAccount window poped up behind VS"

### DIFF
--- a/PowerShellTools/ServiceManagement/PowershellHostProcessHelper.cs
+++ b/PowerShellTools/ServiceManagement/PowershellHostProcessHelper.cs
@@ -21,9 +21,10 @@ namespace PowerShellTools.ServiceManagement
         private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow); 
 
         private static readonly IntPtr HWND_TOPMOST = new IntPtr(-1);
-        private const UInt32 SWP_NOSIZE = 0x0001;
-        private const UInt32 SWP_NOMOVE = 0x0002;
-        private const UInt32 TOPMOST_FLAGS = SWP_NOMOVE | SWP_NOSIZE;
+        private const uint SWP_NOSIZE = 0x0001;
+        private const uint SWP_NOMOVE = 0x0002;
+        private const uint SWP_NOACTIVATE = 0x0010;
+        private const uint TOPMOST_FLAGS = SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE;
         private const int SW_HIDE = 0;
 
         public static PowershellHostProcess CreatePowershellHostProcess()
@@ -45,13 +46,10 @@ namespace PowerShellTools.ServiceManagement
 
             powershellHostProcess.StartInfo.Arguments = hostArgs;
             powershellHostProcess.StartInfo.FileName = path;
-//#if DEBUG
+
             powershellHostProcess.StartInfo.CreateNoWindow = false;
             powershellHostProcess.StartInfo.WindowStyle = ProcessWindowStyle.Normal;
-//#else
-            //powershellHostProcess.StartInfo.UseShellExecute = true;
-            //powershellHostProcess.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
-//#endif
+
             EventWaitHandle readyEvent = new EventWaitHandle(false, EventResetMode.ManualReset, hostProcessReadyEventName);
 
             powershellHostProcess.Start();

--- a/PowerShellTools/ServiceManagement/PowershellHostProcessHelper.cs
+++ b/PowerShellTools/ServiceManagement/PowershellHostProcessHelper.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Reflection;
 using System.Threading;
 using PowerShellTools.Common;
+using System.Runtime.InteropServices;
 
 namespace PowerShellTools.ServiceManagement
 {
@@ -13,6 +14,18 @@ namespace PowerShellTools.ServiceManagement
     /// </summary>
     internal static class PowershellHostProcessHelper
     {
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int W, int H, uint uFlags);
+
+        [DllImport("user32.dll")]
+        private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow); 
+
+        private static readonly IntPtr HWND_TOPMOST = new IntPtr(-1);
+        private const UInt32 SWP_NOSIZE = 0x0001;
+        private const UInt32 SWP_NOMOVE = 0x0002;
+        private const UInt32 TOPMOST_FLAGS = SWP_NOMOVE | SWP_NOSIZE;
+        private const int SW_HIDE = 0;
+
         public static PowershellHostProcess CreatePowershellHostProcess()
         {
             PowerShellToolsPackage.DebuggerReadyEvent.Reset();
@@ -32,13 +45,13 @@ namespace PowerShellTools.ServiceManagement
 
             powershellHostProcess.StartInfo.Arguments = hostArgs;
             powershellHostProcess.StartInfo.FileName = path;
-#if DEBUG
+//#if DEBUG
             powershellHostProcess.StartInfo.CreateNoWindow = false;
             powershellHostProcess.StartInfo.WindowStyle = ProcessWindowStyle.Normal;
-#else
-            powershellHostProcess.StartInfo.UseShellExecute = true;
-            powershellHostProcess.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
-#endif
+//#else
+            //powershellHostProcess.StartInfo.UseShellExecute = true;
+            //powershellHostProcess.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+//#endif
             EventWaitHandle readyEvent = new EventWaitHandle(false, EventResetMode.ManualReset, hostProcessReadyEventName);
 
             powershellHostProcess.Start();
@@ -49,6 +62,12 @@ namespace PowerShellTools.ServiceManagement
             // By then we will bring timeout back here.
             bool success = readyEvent.WaitOne();
             readyEvent.Close();
+
+            MakeTopMost(powershellHostProcess.MainWindowHandle);
+
+            #if !DEBUG
+                ShowWindow(powershellHostProcess.MainWindowHandle, SW_HIDE);
+            #endif
 
             if (!success)
             {
@@ -72,7 +91,12 @@ namespace PowerShellTools.ServiceManagement
             }
 
             return new PowershellHostProcess(powershellHostProcess, endPointGuid);
-        }        
+        }
+
+        private static void MakeTopMost(IntPtr hWnd)
+        {
+            SetWindowPos(hWnd, HWND_TOPMOST, 0, 0, 0, 0, TOPMOST_FLAGS);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
#174

@AndreSayreMSFT @HuanhuanSunMSFT @bmoore-msft @Microsoft/poshtools 

Add-AzureAccount pops its own window for authentication, there is nothing we can pipe back to VS to operate in this case, so we have to put remote host process window(invisible) on top so that the new window from the process can be presented on top of VS.

In order to obtain the invisible window handle, you have to visible it first and then hide it. MSDN: https://msdn.microsoft.com/en-us/library/system.diagnostics.process.mainwindowhandle(v=vs.110).aspx
