### PR TITLE
Fix #287 handle console app input&output from PowerShell host process

### DIFF
--- a/PowerShellTools.HostService/Program.cs
+++ b/PowerShellTools.HostService/Program.cs
@@ -20,7 +20,7 @@ namespace PowerShellTools.HostService
 
         public static int VsProcessId { get; private set; }
 
-        public static int EndpointGuid { get; private set; }
+        public static string EndpointGuid { get; private set; }
 
         [LoaderOptimization(LoaderOptimization.SingleDomain)]
         internal static int Main(string[] args)
@@ -35,7 +35,7 @@ namespace PowerShellTools.HostService
 
             _processExitEvent = new AutoResetEvent(false);
 
-            string EndpointGuid = args[0].Remove(0, Constants.UniqueEndpointArg.Length);
+            EndpointGuid = args[0].Remove(0, Constants.UniqueEndpointArg.Length);
             if (EndpointGuid.Length != Guid.Empty.ToString().Length)
             {
                 return 1;

--- a/PowerShellTools.HostService/Program.cs
+++ b/PowerShellTools.HostService/Program.cs
@@ -20,6 +20,8 @@ namespace PowerShellTools.HostService
 
         public static int VsProcessId { get; private set; }
 
+        public static int EndpointGuid { get; private set; }
+
         [LoaderOptimization(LoaderOptimization.SingleDomain)]
         internal static int Main(string[] args)
         {
@@ -33,8 +35,8 @@ namespace PowerShellTools.HostService
 
             _processExitEvent = new AutoResetEvent(false);
 
-            string endpointGuid = args[0].Remove(0, Constants.UniqueEndpointArg.Length);
-            if (endpointGuid.Length != Guid.Empty.ToString().Length)
+            string EndpointGuid = args[0].Remove(0, Constants.UniqueEndpointArg.Length);
+            if (EndpointGuid.Length != Guid.Empty.ToString().Length)
             {
                 return 1;
             }
@@ -59,7 +61,7 @@ namespace PowerShellTools.HostService
 
             // Step 1: Create the NetNamedPipeBinding. 
             // Note: the setup of the binding should be same as the client side, otherwise, the connection won't get established
-            Uri baseAddress = new Uri(Constants.ProcessManagerHostUri + endpointGuid);
+            Uri baseAddress = new Uri(Constants.ProcessManagerHostUri + EndpointGuid);
             NetNamedPipeBinding binding = new NetNamedPipeBinding(NetNamedPipeSecurityMode.None);
             binding.ReceiveTimeout = TimeSpan.MaxValue;
             binding.SendTimeout = TimeSpan.MaxValue;

--- a/PowerShellTools.HostService/ServiceCommon.cs
+++ b/PowerShellTools.HostService/ServiceCommon.cs
@@ -46,7 +46,7 @@ namespace PowerShellTools.HostService
         /// <param name="msg"></param>
         private static void Log(string msg)
         {
-            Console.WriteLine(msg);
+            Console.WriteLine(string.Format("[{0}]:{1}", Program.EndpointGuid, msg));
         }
     }
 }

--- a/PowerShellTools.HostService/ServiceCommon.cs
+++ b/PowerShellTools.HostService/ServiceCommon.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.PowerShell;
+using PowerShellTools.Common.Debugging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -46,7 +47,7 @@ namespace PowerShellTools.HostService
         /// <param name="msg"></param>
         private static void Log(string msg)
         {
-            Console.WriteLine(string.Format("[{0}]:{1}", Program.EndpointGuid, msg));
+            Console.WriteLine(string.Format(DebugEngineConstants.PowerShellHostProcessLogFormat, Program.EndpointGuid, msg));
         }
     }
 }

--- a/PowerShellTools/DebugEngine/DebugServiceEventsHandlerProxy.cs
+++ b/PowerShellTools/DebugEngine/DebugServiceEventsHandlerProxy.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using PowerShellTools.Common.ServiceManagement.DebuggingContract;
 using Microsoft.VisualStudio.Shell;
+using PowerShellTools.ServiceManagement;
 
 namespace PowerShellTools.DebugEngine
 {
@@ -175,6 +176,17 @@ namespace PowerShellTools.DebugEngine
         {
             return Debugger.HostUi.GetPSCredential(caption, message, userName,
                 targetName, allowedCredentialTypes, options);
+        }
+
+
+        public void StartMonitorUserInputRequest()
+        {
+            PowershellHostProcessHelper.AppRunning = true;
+        }
+
+        public void StopMonitorUserInputRequest()
+        {
+            PowershellHostProcessHelper.AppRunning = false;
         }
     }
 }

--- a/PowerShellTools/DebugEngine/DebugServiceEventsHandlerProxy.cs
+++ b/PowerShellTools/DebugEngine/DebugServiceEventsHandlerProxy.cs
@@ -181,12 +181,18 @@ namespace PowerShellTools.DebugEngine
 
         public void StartMonitorUserInputRequest()
         {
-            PowershellHostProcessHelper.AppRunning = true;
+            if (ConnectionManager.Instance.HostProcess != null)
+            {
+                ConnectionManager.Instance.HostProcess.AppRunning = true;
+            }
         }
 
         public void StopMonitorUserInputRequest()
         {
-            PowershellHostProcessHelper.AppRunning = false;
+            if (ConnectionManager.Instance.HostProcess != null)
+            {
+                ConnectionManager.Instance.HostProcess.AppRunning = false;
+            }
         }
     }
 }

--- a/PowerShellTools/DebugEngine/HostUi.cs
+++ b/PowerShellTools/DebugEngine/HostUi.cs
@@ -240,7 +240,12 @@ namespace PowerShellTools.DebugEngine
         /// <returns>user input string</returns>
         public string ReadLine(string message)
         {
-            return Interaction.InputBox(message, DebugEngineConstants.ReadHostDialogTitle);
+            string input = string.Empty;
+            ThreadHelper.Generic.Invoke(() =>
+            {
+                input = Interaction.InputBox(message, DebugEngineConstants.ReadHostDialogTitle);
+            });
+            return input;
         }
 
         /// <summary>

--- a/PowerShellTools/DebugEngine/HostUi.cs
+++ b/PowerShellTools/DebugEngine/HostUi.cs
@@ -241,10 +241,12 @@ namespace PowerShellTools.DebugEngine
         public string ReadLine(string message)
         {
             string input = string.Empty;
+
             ThreadHelper.Generic.Invoke(() =>
             {
                 input = Interaction.InputBox(message, DebugEngineConstants.ReadHostDialogTitle);
             });
+
             return input;
         }
 

--- a/PowerShellTools/Resources.Designer.cs
+++ b/PowerShellTools/Resources.Designer.cs
@@ -675,6 +675,15 @@ namespace PowerShellTools {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Appliation asks for an input:.
+        /// </summary>
+        public static string UserInputRequestMessage {
+            get {
+                return ResourceManager.GetString("UserInputRequestMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Specifies the variables that the module exports. Wildcards are permitted..
         /// </summary>
         public static string VariablesToExport_Description {

--- a/PowerShellTools/Resources.resx
+++ b/PowerShellTools/Resources.resx
@@ -336,4 +336,7 @@ Would you like to download now?</value>
   <data name="PowerShellToolsInitializeFailed" xml:space="preserve">
     <value>Failed to initialize PowerShell Tools for Visual Studio</value>
   </data>
+  <data name="UserInputRequestMessage" xml:space="preserve">
+    <value>Appliation asks for an input:</value>
+  </data>
 </root>

--- a/PowerShellTools/ServiceManagement/ConnectionManager.cs
+++ b/PowerShellTools/ServiceManagement/ConnectionManager.cs
@@ -23,6 +23,7 @@ namespace PowerShellTools.ServiceManagement
         private ChannelFactory<IPowershellIntelliSenseService> _intelliSenseServiceChannelFactory;
         private ChannelFactory<IPowershellDebuggingService> _debuggingServiceChannelFactory;
         private static readonly ILog Log = LogManager.GetLogger(typeof(PowerShellToolsPackage));
+        private PowerShellHostProcess _hostProcess;
 
         /// <summary>
         /// Event is fired when the connection exception happened.
@@ -83,6 +84,17 @@ namespace PowerShellTools.ServiceManagement
             }
         }
 
+        /// <summary>
+        /// PowerShell host process
+        /// </summary>
+        public PowerShellHostProcess HostProcess
+        {
+            get
+            {
+                return _hostProcess;
+            }
+        }
+
         private void OpenClientConnection()
         {
             lock (_syncObject)
@@ -90,13 +102,13 @@ namespace PowerShellTools.ServiceManagement
                 if (_powershellIntelliSenseService == null || _powershellDebuggingService == null)
                 {
                     EnsureCloseProcess(_process);
-                    var hostProcess = PowershellHostProcessHelper.CreatePowershellHostProcess();
-                    _process = hostProcess.Process;
+                    _hostProcess = PowershellHostProcessHelper.CreatePowershellHostProcess();
+                    _process = _hostProcess.Process;
                     _process.Exited += ConnectionExceptionHandler;
 
                     // net.pipe://localhost/UniqueEndpointGuid/{RelativeUri}
-                    var intelliSenseServiceEndPointAddress = Constants.ProcessManagerHostUri + hostProcess.EndpointGuid + "/" + Constants.IntelliSenseHostRelativeUri;
-                    var deubggingServiceEndPointAddress = Constants.ProcessManagerHostUri + hostProcess.EndpointGuid + "/" + Constants.DebuggingHostRelativeUri;
+                    var intelliSenseServiceEndPointAddress = Constants.ProcessManagerHostUri + _hostProcess.EndpointGuid + "/" + Constants.IntelliSenseHostRelativeUri;
+                    var deubggingServiceEndPointAddress = Constants.ProcessManagerHostUri + _hostProcess.EndpointGuid + "/" + Constants.DebuggingHostRelativeUri;
 
                     try
                     {

--- a/PowerShellTools/ServiceManagement/PowershellHostProcessHelper.cs
+++ b/PowerShellTools/ServiceManagement/PowershellHostProcessHelper.cs
@@ -130,7 +130,7 @@ namespace PowerShellTools.ServiceManagement
                 if (PowerShellToolsPackage.Debugger != null &&
                     PowerShellToolsPackage.Debugger.HostUi != null)
                 {
-                    PowerShellToolsPackage.Debugger.HostUi.VsOutputString(outputData);
+                    PowerShellToolsPackage.Debugger.HostUi.VsOutputString(outputData + Environment.NewLine);
                 }
             }
         }

--- a/PowerShellTools/ServiceManagement/PowershellHostProcessHelper.cs
+++ b/PowerShellTools/ServiceManagement/PowershellHostProcessHelper.cs
@@ -155,7 +155,7 @@ namespace PowerShellTools.ServiceManagement
                         if (PowerShellToolsPackage.Debugger != null &&
                             PowerShellToolsPackage.Debugger.HostUi != null)
                         {
-                            string inputText = PowerShellToolsPackage.Debugger.HostUi.ReadLine(string.Empty);
+                            string inputText = PowerShellToolsPackage.Debugger.HostUi.ReadLine(Resources.UserInputRequestMessage);
 
                             // Feed into stdin stream
                             _inputStreamWriter.WriteLine(inputText);

--- a/PowerShellTools/ServiceManagement/PowershellHostProcessHelper.cs
+++ b/PowerShellTools/ServiceManagement/PowershellHostProcessHelper.cs
@@ -79,9 +79,7 @@ namespace PowerShellTools.ServiceManagement
 
             MakeTopMost(powerShellHostProcess.MainWindowHandle);
 
-            #if !DEBUG
-                ShowWindow(powershellHostProcess.MainWindowHandle, SW_HIDE);
-            #endif
+            ShowWindow(powerShellHostProcess.MainWindowHandle, SW_HIDE);
 
             if (!success)
             {

--- a/PowerShellTools/ServiceManagement/PowershellHostProcessHelper.cs
+++ b/PowerShellTools/ServiceManagement/PowershellHostProcessHelper.cs
@@ -32,7 +32,7 @@ namespace PowerShellTools.ServiceManagement
 
         private static readonly ILog Log = LogManager.GetLogger(typeof(PowershellHostProcessHelper));
 
-        public static Guid EndPointGuid { get; set; }
+        private static Guid EndPointGuid { get; set; }
 
         public static PowerShellHostProcess CreatePowershellHostProcess()
         {
@@ -72,8 +72,6 @@ namespace PowerShellTools.ServiceManagement
 
             powerShellHostProcess.BeginOutputReadLine();
             powerShellHostProcess.BeginErrorReadLine();
-
-            
 
             // For now we dont set timeout and wait infinitely
             // Further UI work might enable some better UX like retry logic for case where remote process being unresponsive
@@ -162,6 +160,9 @@ namespace PowerShellTools.ServiceManagement
             private set; 
         }
 
+        /// <summary>
+        /// App running flag indicating if there is app runing on PSHost
+        /// </summary>
         public bool AppRunning
         {
             get
@@ -196,7 +197,7 @@ namespace PowerShellTools.ServiceManagement
         /// Will be started once app begins to run on remote PowerShell host service
         /// Stopped once app exits
         /// </remarks>
-        public void MonitorUserInputRequest()
+        private void MonitorUserInputRequest()
         {
             StreamWriter _inputStreamWriter = Process.StandardInput;
 
@@ -222,7 +223,7 @@ namespace PowerShellTools.ServiceManagement
                     }
                 }
 
-                Thread.Sleep(500);
+                Thread.Sleep(50);
             }
 
             _inputStreamWriter.Flush();

--- a/PowershellTools.Common/Debugging/DebugEngineConstants.cs
+++ b/PowershellTools.Common/Debugging/DebugEngineConstants.cs
@@ -125,5 +125,8 @@ param (
         // {2} - CategoryInfo
         // {3} - FullyQualifiedErrorId
         public const string TerminatingErrorFormat = "[ERROR] {0}{1}[ERROR] + CategoryInfo          : {2}{1}[ERROR] + FullyQualifiedErrorId : {3}{1}";
+
+        public const string PowerShellHostProcessLogTag = "[{0}]:";
+        public const string PowerShellHostProcessLogFormat = PowerShellHostProcessLogTag + "{1}";
     }
 }

--- a/PowershellTools.Common/ServiceManagement/DebuggingContract/IDebugEngineCallback.cs
+++ b/PowershellTools.Common/ServiceManagement/DebuggingContract/IDebugEngineCallback.cs
@@ -58,5 +58,11 @@ namespace PowerShellTools.Common.ServiceManagement.DebuggingContract
 
         [OperationContract(IsOneWay = false)]
         void SetRemoteRunspace(bool enabled);
+
+        [OperationContract(IsOneWay = false)]
+        void StartMonitorUserInputRequest();
+
+        [OperationContract(IsOneWay = false)]
+        void StopMonitorUserInputRequest();
     }
 }

--- a/PowershellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingService.cs
+++ b/PowershellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingService.cs
@@ -362,7 +362,7 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
             }
             catch (Exception ex)
             {
-                ServiceCommon.Log("Terminating error,  Exception: {0}", ex);              
+                ServiceCommon.Log("Terminating error,  Exception: {0}", ex.Message);
                 OnTerminatingException(ex);
                 return false;
             }

--- a/PowershellTools.HostService/ServiceManagement/Debugging/PowershellServiceHost.cs
+++ b/PowershellTools.HostService/ServiceManagement/Debugging/PowershellServiceHost.cs
@@ -96,7 +96,10 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
         /// </summary>
         public override void NotifyBeginApplication()
         {
-            return;
+            if (_callback != null)
+            {
+                _callback.StartMonitorUserInputRequest();
+            }
         }
 
         /// <summary>
@@ -107,7 +110,10 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
         /// </summary>
         public override void NotifyEndApplication()
         {
-            return;
+            if (_callback != null)
+            {
+                _callback.StopMonitorUserInputRequest();
+            }
         }
 
         /// <summary>

--- a/PowershellTools.HostService/ServiceManagement/Debugging/PowershellServiceHost.cs
+++ b/PowershellTools.HostService/ServiceManagement/Debugging/PowershellServiceHost.cs
@@ -121,6 +121,7 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
         {
 
         }
+
         /// <summary>
         /// The culture information of the thread that created
         /// this object.


### PR DESCRIPTION
#287

@AndreSayreMSFT  @HuanhuanSunMSFT  @Microsoft/poshtools 

Description: 
- Redirect and listen for stdout and stderr for output info from app running in PShost
- Redirect and monitor the user input request since app starts, and stops once app exits.
- Console.ReadKey is not yet supported due to the nature of how we currently prompt for user input(it is through GUI), in order to support it, we need some infrastructure work for REPL window so that it can prompt for user input there.
