### PR TITLE
Fix REPL exception when first brought up on debugging UI context

### DIFF
--- a/PowerShellTools.HostService/PowerShellServiceHostBehaviorAttribute.cs
+++ b/PowerShellTools.HostService/PowerShellServiceHostBehaviorAttribute.cs
@@ -30,7 +30,7 @@ namespace PowerShellTools.HostService
         public bool HandleError(Exception error)
         {
             // Log the error details on server side
-            ServiceCommon.Log("PowershellHostService: {0}", error.ToString());
+            ServiceCommon.Log("PowershellHostService: {0}", error.Message.ToString());
 
             // Let the other ErrorHandler do their jobs
             return true;

--- a/PowerShellTools.HostService/ServiceManagement/Debugging/PowerShellDebuggingServiceEventHandlers.cs
+++ b/PowerShellTools.HostService/ServiceManagement/Debugging/PowerShellDebuggingServiceEventHandlers.cs
@@ -205,7 +205,7 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
                 }
                 catch (Exception ex)
                 {
-                    ServiceCommon.Log("Failed to create local copy for downloaded file due to exception: {0}", ex);
+                    ServiceCommon.Log("Failed to create local copy for downloaded file due to exception: {0}", ex.Message);
                 }
             }
         }

--- a/PowerShellTools/DebugEngine/HostUi.cs
+++ b/PowerShellTools/DebugEngine/HostUi.cs
@@ -124,14 +124,15 @@ namespace PowerShellTools.DebugEngine
         {
             try
             {
+                string prompt = string.Empty;
+
                 if (DebuggingService != null)
                 {
-                    string prompt;
                     if (IsDebuggingCommandReady)
                     {
                         prompt = DebuggingService.ExecuteDebuggingCommandOutNull(DebugEngineConstants.GetPrompt);
                     }
-                    else
+                    else if (DebuggingService.GetRunspaceAvailability() == RunspaceAvailability.Available)
                     {
                         prompt = DebuggingService.GetPrompt();
                     }
@@ -139,7 +140,7 @@ namespace PowerShellTools.DebugEngine
                     return prompt;
                 }
 
-                return string.Empty;
+                return prompt;
             }
             catch
             {

--- a/PowershellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingService.cs
+++ b/PowershellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingService.cs
@@ -552,7 +552,7 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
                     }
                     catch (Exception ex)
                     {
-                        ServiceCommon.Log("Property infomation is not able to be retrieved through reflection due to exception: {0} {2} InnerException: {1}", ex, ex.InnerException, Environment.NewLine);
+                        ServiceCommon.Log("Property infomation is not able to be retrieved through reflection due to exception: {0} {2} InnerException: {1}", ex.Message, ex.InnerException, Environment.NewLine);
                     }
                 }
             }


### PR DESCRIPTION
#339

@AndreSayreMSFT @HuanhuanSunMSFT 
We don't need to refresh prompt in this case as the debugging session will do it later anyway
