### PR TITLE
Bugfix for #209 Diff powershell files will crash VS

### DIFF
--- a/PowerShellTools/LanguageService/CodeWindowManager.cs
+++ b/PowerShellTools/LanguageService/CodeWindowManager.cs
@@ -44,7 +44,14 @@ namespace PowerShellTools.LanguageService
         {
             _window = codeWindow;
             _textView = textView;
-            _textView.TextBuffer.Properties.TryGetProperty<IPowerShellTokenizationService>(BufferProperties.PowerShellTokenizer, out _tokenizer);
+	    if (_textView.TextBuffer.ContentType.IsOfType(PowerShellConstants.LanguageName))
+	    {
+		_textView.TextBuffer.Properties.TryGetProperty<IPowerShellTokenizationService>(BufferProperties.PowerShellTokenizer, out _tokenizer);
+	    }
+	    else
+	    {
+		_tokenizer = new PowerShellTokenizationService(_textView.TextBuffer);
+	    }
 
             Debug.Assert(_tokenizer != null, "PowerShell Tokenizer not found on textBuffer from CodeWindowManager");
 


### PR DESCRIPTION
Normally, opening a powershell file will create a TextBuffer with ContentType "PowerShell". However, when diffing a powershell, the TextBuffer ContentType is a combination of two TextBuffers, both of which have ContentType as "PowerShell". But the combination TextBuffer's ContentType is with name "projection". We don't put anything into this TextBuffer, meaning we can get nothing from it, neither. Then we don't, we create it one ourselves here.
@AndreSayreMSFT @EricMSFT @Microsoft/poshtools 
