### PR TITLE
PowerShell v3 compatibility issue on debugging

### DIFF
--- a/PowerShellTools.HostService/Resources.Designer.cs
+++ b/PowerShellTools.HostService/Resources.Designer.cs
@@ -95,5 +95,14 @@ namespace PowerShellTools.HostService {
                 return ResourceManager.GetString("Error_PipelineBusy", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Warning: You&apos;ll need higher version(v4.0 or higher) of PowerShell to debug your remote script execution..
+        /// </summary>
+        public static string Warning_HigherVersionRequiredForDebugging {
+            get {
+                return ResourceManager.GetString("Warning_HigherVersionRequiredForDebugging", resourceCulture);
+            }
+        }
     }
 }

--- a/PowerShellTools.HostService/Resources.Designer.cs
+++ b/PowerShellTools.HostService/Resources.Designer.cs
@@ -97,7 +97,7 @@ namespace PowerShellTools.HostService {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Warning: You&apos;ll need higher version(v4.0 or higher) of PowerShell to debug your remote script execution..
+        ///   Looks up a localized string similar to Warning: PowerShell v4.0 or later is needed to debug during remote script execution..
         /// </summary>
         public static string Warning_HigherVersionRequiredForDebugging {
             get {

--- a/PowerShellTools.HostService/Resources.resx
+++ b/PowerShellTools.HostService/Resources.resx
@@ -131,6 +131,6 @@
     <value>Pipeline not executed because a pipeline is already executing. Pipelines cannot be executed concurrently.</value>
   </data>
   <data name="Warning_HigherVersionRequiredForDebugging" xml:space="preserve">
-    <value>Warning: You'll need higher version(v4.0 or higher) of PowerShell to debug your remote script execution.</value>
+    <value>Warning: PowerShell v4.0 or later is needed to debug during remote script execution.</value>
   </data>
 </root>

--- a/PowerShellTools.HostService/Resources.resx
+++ b/PowerShellTools.HostService/Resources.resx
@@ -130,4 +130,7 @@
   <data name="Error_PipelineBusy" xml:space="preserve">
     <value>Pipeline not executed because a pipeline is already executing. Pipelines cannot be executed concurrently.</value>
   </data>
+  <data name="Warning_HigherVersionRequiredForDebugging" xml:space="preserve">
+    <value>Warning: You'll need higher version(v4.0 or higher) of PowerShell to debug your remote script execution.</value>
+  </data>
 </root>

--- a/PowerShellTools.HostService/ServiceManagement/Debugging/PowerShellDebuggingServiceEventHandlers.cs
+++ b/PowerShellTools.HostService/ServiceManagement/Debugging/PowerShellDebuggingServiceEventHandlers.cs
@@ -1,4 +1,5 @@
-﻿using PowerShellTools.Common.ServiceManagement.DebuggingContract;
+﻿using PowerShellTools.Common;
+using PowerShellTools.Common.ServiceManagement.DebuggingContract;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -91,14 +92,16 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
         private void Debugger_DebuggerStop(object sender, DebuggerStopEventArgs e)
         {
             ServiceCommon.Log("Debugger stopped ...");
-            try
+
+            if (_installedPowershellVersion < RequiredPowerShellVersionForRemoteSessionDebugging)
             {
                 RefreshScopedVariable();
                 RefreshCallStack();
             }
-            catch (Exception ex)
+            else
             {
-                ServiceCommon.Log("typeload ex" + ex.Message);
+                RefreshScopedVariable40();
+                RefreshCallStack40();
             }
 
             ServiceCommon.LogCallbackEvent("Callback to client, and wait for debuggee to resume");

--- a/PowerShellTools.HostService/ServiceManagement/Debugging/PowerShellDebuggingServiceEventHandlers.cs
+++ b/PowerShellTools.HostService/ServiceManagement/Debugging/PowerShellDebuggingServiceEventHandlers.cs
@@ -93,7 +93,7 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
         {
             ServiceCommon.Log("Debugger stopped ...");
 
-            if (_installedPowershellVersion < RequiredPowerShellVersionForRemoteSessionDebugging)
+            if (_installedPowerShellVersion < RequiredPowerShellVersionForRemoteSessionDebugging)
             {
                 RefreshScopedVariable();
                 RefreshCallStack();

--- a/PowerShellTools.HostService/ServiceManagement/Debugging/PowerShellDebuggingServiceEventHandlers.cs
+++ b/PowerShellTools.HostService/ServiceManagement/Debugging/PowerShellDebuggingServiceEventHandlers.cs
@@ -91,8 +91,15 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
         private void Debugger_DebuggerStop(object sender, DebuggerStopEventArgs e)
         {
             ServiceCommon.Log("Debugger stopped ...");
-            RefreshScopedVariable();
-            RefreshCallStack();
+            try
+            {
+                RefreshScopedVariable();
+                RefreshCallStack();
+            }
+            catch (Exception ex)
+            {
+                ServiceCommon.Log("typeload ex" + ex.Message);
+            }
 
             ServiceCommon.LogCallbackEvent("Callback to client, and wait for debuggee to resume");
             if (e.Breakpoints.Count > 0)

--- a/PowerShellTools.HostService/ServiceManagement/Debugging/PowerShellDebuggingServiceUtilities40.cs
+++ b/PowerShellTools.HostService/ServiceManagement/Debugging/PowerShellDebuggingServiceUtilities40.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PowerShellTools.HostService.ServiceManagement.Debugging
+{
+    /// <summary>
+    /// PowerShell v4.0+ only specific utilities
+    /// </summary>
+    public partial class PowerShellDebuggingService
+    {
+        private void RefreshScopedVariable40()
+        {
+            ServiceCommon.Log("Debuggger stopped, let us retreive all local variable in scope");
+            if (_runspace.ConnectionInfo != null)
+            {
+                PSCommand psCommand = new PSCommand();
+                psCommand.AddScript("Get-Variable");
+                var output = new PSDataCollection<PSObject>();
+                DebuggerCommandResults results = _runspace.Debugger.ProcessCommand(psCommand, output);
+                _varaiables = output;
+            }
+            else
+            {
+                RefreshScopedVariable();
+            }
+        }
+
+        private void RefreshCallStack40()
+        {
+            ServiceCommon.Log("Debuggger stopped, let us retreive all call stack frames");
+            if (_runspace.ConnectionInfo != null)
+            {
+                PSCommand psCommand = new PSCommand();
+                psCommand.AddScript("Get-PSCallstack");
+                var output = new PSDataCollection<PSObject>();
+                DebuggerCommandResults results = _runspace.Debugger.ProcessCommand(psCommand, output);
+                _callstack = output;
+            }
+            else
+            {
+                RefreshCallStack();
+            }
+        }
+
+        private void SetRemoteScriptDebugMode40(System.Management.Automation.Runspaces.Runspace runspace)
+        {
+            runspace.Debugger.SetDebugMode(DebugModes.RemoteScript);
+        }
+    }
+}

--- a/PowerShellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingServiceUtilities.cs
+++ b/PowerShellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingServiceUtilities.cs
@@ -22,7 +22,7 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
     {
         // Potential TODO: Refactor this class into either a static Utilities class
 
-        private const string DteVariableName= "dte";
+        private const string DteVariableName = "dte";
 
         private void SetRunspace(Runspace runspace)
         {
@@ -135,13 +135,16 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
             }
         }
 
-        private void objects_DataAdded(object sender, DataAddedEventArgs e)
+        private void objects_DataAdded(object sender, EventArgs e)
         {
-            var list = sender as PSDataCollection<PSObject>;
+            PipelineReader<PSObject> output = sender as PipelineReader<PSObject>;
             StringBuilder outputString = new StringBuilder();
-            foreach (PSObject obj in list)
+            if (output != null)
             {
-                outputString.AppendLine(obj.ToString());
+                while (output.Count > 0)
+                {
+                    outputString.AppendLine(output.Read().ToString());
+                }
             }
 
             if (_debugOutput)
@@ -232,7 +235,7 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
 
         private void ReleaseWaitHandler()
         {
-            _debuggingCommand = DebugEngineConstants.Debugger_Stop;
+            _resumeAction = DebugEngineConstants.Debugger_Stop;
             _pausedEvent.Set();
         }
 
@@ -291,9 +294,11 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
                 _debugOutput = output;
                 _debugCommandOutput = string.Empty;
                 _debuggingCommand = debuggingCommand;
+                _debugCommandEvent.Reset();
                 _pausedEvent.Set();
                 _debugCommandEvent.WaitOne();
                 _debugOutput = true;
+                _debuggingCommand = string.Empty;
                 return _debugCommandOutput;
             }
         }

--- a/PowerShellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingServiceUtilities.cs
+++ b/PowerShellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingServiceUtilities.cs
@@ -41,7 +41,7 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
         {
             if (_runspace != null)
             {
-                if (_runspace.ConnectionInfo == null || _installedPowershellVersion >= RequiredPowerShellVersionForRemoteSessionDebugging)
+                if (_runspace.ConnectionInfo == null || _installedPowerShellVersion >= RequiredPowerShellVersionForRemoteSessionDebugging)
                 {
                     runspace.Debugger.DebuggerStop += Debugger_DebuggerStop;
                     runspace.Debugger.BreakpointUpdated += Debugger_BreakpointUpdated;
@@ -55,7 +55,7 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
         {
             if (_runspace != null)
             {
-                if (_runspace.ConnectionInfo == null || _installedPowershellVersion >= RequiredPowerShellVersionForRemoteSessionDebugging)
+                if (_runspace.ConnectionInfo == null || _installedPowerShellVersion >= RequiredPowerShellVersionForRemoteSessionDebugging)
                 {
                     runspace.Debugger.DebuggerStop -= Debugger_DebuggerStop;
                     runspace.Debugger.BreakpointUpdated -= Debugger_BreakpointUpdated;

--- a/PowerShellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingServiceUtilities.cs
+++ b/PowerShellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingServiceUtilities.cs
@@ -282,5 +282,20 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
                 return _debugCommandOutput;
             }
         }
+
+        private void objects_DataAdded(object sender, DataAddedEventArgs e)
+        {
+            var list = sender as PSDataCollection<PSObject>;
+            StringBuilder outputString = new StringBuilder();
+            foreach (PSObject obj in list)
+            {
+                outputString.AppendLine(obj.ToString());
+            }
+
+            if (_debugOutput)
+            {
+                NotifyOutputString(outputString.ToString());
+            }
+        }
     }
 }

--- a/PowerShellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingServiceUtilities.cs
+++ b/PowerShellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingServiceUtilities.cs
@@ -135,24 +135,6 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
             }
         }
 
-        private void objects_DataAdded(object sender, EventArgs e)
-        {
-            PipelineReader<PSObject> output = sender as PipelineReader<PSObject>;
-            StringBuilder outputString = new StringBuilder();
-            if (output != null)
-            {
-                while (output.Count > 0)
-                {
-                    outputString.AppendLine(output.Read().ToString());
-                }
-            }
-
-            if (_debugOutput)
-            {
-                NotifyOutputString(outputString.ToString());
-            }
-        }
-
         private void InitializeRunspace(PSHost psHost)
         {
             ServiceCommon.Log("Initializing run space with debugger");

--- a/PowerShellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingServiceUtilities.cs
+++ b/PowerShellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingServiceUtilities.cs
@@ -44,44 +44,22 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
         private void RefreshScopedVariable()
         {
             ServiceCommon.Log("Debuggger stopped, let us retreive all local variable in scope");
-            if (_runspace.ConnectionInfo != null)
+            using (var pipeline = (_runspace.CreateNestedPipeline()))
             {
-                PSCommand psCommand = new PSCommand();
-                psCommand.AddScript("Get-Variable");
-                var output = new PSDataCollection<PSObject>();
-                DebuggerCommandResults results = _runspace.Debugger.ProcessCommand(psCommand, output);
-                _varaiables = output;
-            }
-            else
-            {
-                using (var pipeline = (_runspace.CreateNestedPipeline()))
-                {
-                    var command = new Command("Get-Variable");
-                    pipeline.Commands.Add(command);
-                    _varaiables = pipeline.Invoke();
-                }
+                var command = new Command("Get-Variable");
+                pipeline.Commands.Add(command);
+                _varaiables = pipeline.Invoke();
             }
         }
 
         private void RefreshCallStack()
         {
             ServiceCommon.Log("Debuggger stopped, let us retreive all call stack frames");
-            if (_runspace.ConnectionInfo != null)
+            using (var pipeline = (_runspace.CreateNestedPipeline()))
             {
-                PSCommand psCommand = new PSCommand();
-                psCommand.AddScript("Get-PSCallstack");
-                var output = new PSDataCollection<PSObject>();
-                DebuggerCommandResults results = _runspace.Debugger.ProcessCommand(psCommand, output);
-                _callstack = output;
-            }
-            else
-            {
-                using (var pipeline = (_runspace.CreateNestedPipeline()))
-                {
-                    var command = new Command("Get-PSCallstack");
-                    pipeline.Commands.Add(command);
-                    _callstack = pipeline.Invoke();
-                }
+                var command = new Command("Get-PSCallstack");
+                pipeline.Commands.Add(command);
+                _callstack = pipeline.Invoke();
             }
         }
 

--- a/PowerShellTools/DebugEngine/BreakpointManager.cs
+++ b/PowerShellTools/DebugEngine/BreakpointManager.cs
@@ -31,10 +31,11 @@ namespace PowerShellTools.DebugEngine
         /// </summary>
         public event EventHandler<DebuggerBreakpointUpdatedEventArgs> BreakpointUpdated;
 
-        public ScriptDebugger Debugger{
-            get 
+        public ScriptDebugger Debugger
+        {
+            get
             {
-                if(_debugger == null)
+                if (_debugger == null)
                     return PowerShellToolsPackage.Debugger;
 
                 return _debugger;
@@ -53,7 +54,7 @@ namespace PowerShellTools.DebugEngine
         /// Ctor
         /// </summary>
         /// <param name="debugger">Script debugger</param>
-        public BreakpointManager(ScriptDebugger debugger) 
+        public BreakpointManager(ScriptDebugger debugger)
             : this()
         {
             _debugger = debugger;
@@ -88,7 +89,7 @@ namespace PowerShellTools.DebugEngine
                 }
             }
         }
-        
+
         /// <summary>
         /// Placeholder for future support on debugging command in REPL window
         /// Breakpoint has been updated
@@ -150,7 +151,7 @@ namespace PowerShellTools.DebugEngine
                 }
                 else
                 {
-                    Debugger.ExecuteDebuggingCommand(string.Format(DebugEngineConstants.SetPSBreakpoint, breakpoint.File, breakpoint.Line));
+                    Debugger.DebuggingService.ExecuteDebuggingCommandOutNull(string.Format(DebugEngineConstants.SetPSBreakpoint, breakpoint.File, breakpoint.Line));
                 }
             }
             catch (Exception ex)
@@ -181,8 +182,8 @@ namespace PowerShellTools.DebugEngine
                     int id = Debugger.DebuggingService.GetPSBreakpointId(new PowershellBreakpoint(breakpoint.File, breakpoint.Line, breakpoint.Column));
                     if (id >= 0)
                     {
-                        Debugger.ExecuteDebuggingCommand(
-                                fEnable == 0 ? 
+                        Debugger.DebuggingService.ExecuteDebuggingCommandOutNull(
+                                fEnable == 0 ?
                                 string.Format(DebugEngineConstants.DisablePSBreakpoint, id) :
                                 string.Format(DebugEngineConstants.EnablePSBreakpoint, id));
                     }
@@ -213,7 +214,7 @@ namespace PowerShellTools.DebugEngine
                     int id = Debugger.DebuggingService.GetPSBreakpointId(new PowershellBreakpoint(breakpoint.File, breakpoint.Line, breakpoint.Column));
                     if (id >= 0)
                     {
-                        Debugger.ExecuteDebuggingCommand(string.Format(DebugEngineConstants.RemovePSBreakpoint, id));
+                        Debugger.DebuggingService.ExecuteDebuggingCommandOutNull(string.Format(DebugEngineConstants.RemovePSBreakpoint, id));
                     }
                 }
             }

--- a/PowerShellTools/DebugEngine/DebugServiceEventsHandlerProxy.cs
+++ b/PowerShellTools/DebugEngine/DebugServiceEventsHandlerProxy.cs
@@ -21,7 +21,8 @@ namespace PowerShellTools.DebugEngine
         private ScriptDebugger _debugger;
         private bool _uiOutput;
 
-        public DebugServiceEventsHandlerProxy(){}
+        public DebugServiceEventsHandlerProxy()
+            : this(null, true) { }
 
         public DebugServiceEventsHandlerProxy(ScriptDebugger debugger, bool uiOutput)
         {
@@ -31,7 +32,7 @@ namespace PowerShellTools.DebugEngine
 
         public ScriptDebugger Debugger
         {
-            get 
+            get
             {
                 if (_debugger == null)
                 {

--- a/PowerShellTools/DebugEngine/ScriptDebugger.cs
+++ b/PowerShellTools/DebugEngine/ScriptDebugger.cs
@@ -120,14 +120,14 @@ namespace PowerShellTools.DebugEngine
             catch (DebugEngineInternalException dbgEx)
             {
                 Log.Debug(dbgEx.Message);
-                DebuggingService.ExecuteDebuggingCommandOutDefault(DebugEngineConstants.Debugger_Stop);
+                DebuggingService.SetDebuggerResumeAction(DebugEngineConstants.Debugger_Stop);
 
                 IsDebuggingCommandReady = false;
             }
             catch (Exception ex)
             {
                 Log.Debug(ex.Message);
-                DebuggingService.ExecuteDebuggingCommandOutDefault(DebugEngineConstants.Debugger_Stop);
+                DebuggingService.SetDebuggerResumeAction(DebugEngineConstants.Debugger_Stop);
 
                 IsDebuggingCommandReady = false;
                 throw;
@@ -135,7 +135,7 @@ namespace PowerShellTools.DebugEngine
             finally
             {
                 Log.Debug("Waiting for debuggee to resume.");
-                
+
                 IsDebuggingCommandReady = true;
                 RefreshPrompt();
             }
@@ -254,7 +254,7 @@ namespace PowerShellTools.DebugEngine
                 _stoppingCompleteEvent.Reset();
                 if (IsDebuggingCommandReady)
                 {
-                    DebuggingService.ExecuteDebuggingCommandOutDefault(DebugEngineConstants.Debugger_Stop);
+                    DebuggingService.SetDebuggerResumeAction(DebugEngineConstants.Debugger_Stop);
                     IsDebuggingCommandReady = false;
                 }
                 else
@@ -280,7 +280,7 @@ namespace PowerShellTools.DebugEngine
         public void StepOver()
         {
             Log.Info("StepOver");
-            DebuggingService.ExecuteDebuggingCommandOutDefault(DebugEngineConstants.Debugger_StepOver);
+            DebuggingService.SetDebuggerResumeAction(DebugEngineConstants.Debugger_StepOver);
             IsDebuggingCommandReady = false;
         }
 
@@ -290,7 +290,7 @@ namespace PowerShellTools.DebugEngine
         public void StepInto()
         {
             Log.Info("StepInto");
-            DebuggingService.ExecuteDebuggingCommandOutDefault(DebugEngineConstants.Debugger_StepInto);
+            DebuggingService.SetDebuggerResumeAction(DebugEngineConstants.Debugger_StepInto);
             IsDebuggingCommandReady = false;
         }
 
@@ -300,7 +300,7 @@ namespace PowerShellTools.DebugEngine
         public void StepOut()
         {
             Log.Info("StepOut");
-            DebuggingService.ExecuteDebuggingCommandOutDefault(DebugEngineConstants.Debugger_StepOut);
+            DebuggingService.SetDebuggerResumeAction(DebugEngineConstants.Debugger_StepOut);
             IsDebuggingCommandReady = false;
         }
 
@@ -310,7 +310,7 @@ namespace PowerShellTools.DebugEngine
         public void Continue()
         {
             Log.Info("Continue");
-            DebuggingService.ExecuteDebuggingCommandOutDefault(DebugEngineConstants.Debugger_Continue);
+            DebuggingService.SetDebuggerResumeAction(DebugEngineConstants.Debugger_Continue);
             IsDebuggingCommandReady = false;
         }
 

--- a/PowerShellTools/DependencyValidator.cs
+++ b/PowerShellTools/DependencyValidator.cs
@@ -4,6 +4,7 @@ using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.Win32;
 using System.ComponentModel.Composition;
+using PowerShellTools.Common;
 
 namespace PowerShellTools
 {
@@ -62,29 +63,7 @@ namespace PowerShellTools
         {
             get
             {
-                var version = new Version(0, 0);
-                using (var reg = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\PowerShell\3\PowerShellEngine"))
-                {
-                    if (reg != null)
-                    {
-                        var versionString = reg.GetValue("PowerShellVersion") as string;
-
-                        Version.TryParse(versionString, out version);
-                        return version;
-                    }
-                }
-
-                using (var reg = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\PowerShell\1\PowerShellEngine"))
-                {
-                    if (reg != null)
-                    {
-                        var versionString = reg.GetValue("PowerShellVersion") as string;
-                        Version.TryParse(versionString, out version);
-                        return version;
-                    }
-                }
-
-                return version;
+                return DependencyUtilities.GetInstalledPowerShellVersion();
             }
         }
     }

--- a/PowershellTools.Common/Constants.cs
+++ b/PowershellTools.Common/Constants.cs
@@ -41,5 +41,16 @@ namespace PowerShellTools.Common
         /// This is the GUID of the Visual Studio UI Context when in PowerShell debug mode.
         /// </summary>
         public static readonly Guid PowerShellDebuggingUiContextGuid = new Guid(PowerShellDebuggingUiContextString);
+        
+        /// <summary>
+        /// PowerShell install version registry key
+        /// </summary>
+        public const string NewInstalledPowerShellRegKey = @"Software\Microsoft\PowerShell\3\PowerShellEngine";
+        public const string LegacyInstalledPowershellRegKey = @"Software\Microsoft\PowerShell\1\PowerShellEngine";
+
+        /// <summary>
+        /// PowerShell install version registry key name
+        /// </summary>
+        public const string PowerShellVersionRegKeyName = "PowerShellVersion";
     }
 }

--- a/PowershellTools.Common/Debugging/DebugEngineConstants.cs
+++ b/PowershellTools.Common/Debugging/DebugEngineConstants.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Management.Automation;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -25,7 +26,7 @@ namespace PowerShellTools.Common.Debugging
         /// Pattern sample: Maching pattern like ". 'c:\test\test.ps1' -param1 val"
         /// </remarks>
         public const string ExecutionCommandPattern = @"^\.\s\'.*?\'.*$";
-        
+
         /// <summary>
         /// Match the script file name from execution command
         /// </summary>
@@ -84,7 +85,7 @@ param (
         }
     }
 ";
-        
+
         /// <summary>
         /// The parameter name of the function to be registered
         /// </summary>
@@ -106,11 +107,11 @@ param (
         public const string ExitRemoteSessionDefaultCommand = "Exit-PSSession";
 
         // PowerShell debugging command
-        public const string Debugger_Stop = "q";
-        public const string Debugger_StepOver = "v";
-        public const string Debugger_StepInto = "s";
-        public const string Debugger_StepOut = "o";
-        public const string Debugger_Continue = "c";
+        public const DebuggerResumeAction Debugger_Stop = DebuggerResumeAction.Stop;
+        public const DebuggerResumeAction Debugger_StepOver = DebuggerResumeAction.StepOver;
+        public const DebuggerResumeAction Debugger_StepInto = DebuggerResumeAction.StepInto;
+        public const DebuggerResumeAction Debugger_StepOut = DebuggerResumeAction.StepOut;
+        public const DebuggerResumeAction Debugger_Continue = DebuggerResumeAction.Continue;
 
         // PowerShell breakpoint command
         public const string SetPSBreakpoint = "Set-PSBreakpoint -Script \"{0}\" -Line {1}";

--- a/PowershellTools.Common/DependencyUtilities.cs
+++ b/PowershellTools.Common/DependencyUtilities.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PowerShellTools.Common
+{
+    public static class DependencyUtilities
+    {
+        public static Version GetInstalledPowerShellVersion()
+        {
+            var version = new Version(0, 0);
+            using (var reg = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\PowerShell\3\PowerShellEngine"))
+            {
+                if (reg != null)
+                {
+                    var versionString = reg.GetValue("PowerShellVersion") as string;
+
+                    Version.TryParse(versionString, out version);
+                    return version;
+                }
+            }
+
+            using (var reg = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\PowerShell\1\PowerShellEngine"))
+            {
+                if (reg != null)
+                {
+                    var versionString = reg.GetValue("PowerShellVersion") as string;
+                    Version.TryParse(versionString, out version);
+                    return version;
+                }
+            }
+
+            return version;
+        }
+    }
+}

--- a/PowershellTools.Common/DependencyUtilities.cs
+++ b/PowershellTools.Common/DependencyUtilities.cs
@@ -12,22 +12,22 @@ namespace PowerShellTools.Common
         public static Version GetInstalledPowerShellVersion()
         {
             var version = new Version(0, 0);
-            using (var reg = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\PowerShell\3\PowerShellEngine"))
+            using (var reg = Registry.LocalMachine.OpenSubKey(Constants.NewInstalledPowerShellRegKey))
             {
                 if (reg != null)
                 {
-                    var versionString = reg.GetValue("PowerShellVersion") as string;
+                    var versionString = reg.GetValue(Constants.PowerShellVersionRegKeyName) as string;
 
                     Version.TryParse(versionString, out version);
                     return version;
                 }
             }
 
-            using (var reg = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\PowerShell\1\PowerShellEngine"))
+            using (var reg = Registry.LocalMachine.OpenSubKey(Constants.LegacyInstalledPowershellRegKey))
             {
                 if (reg != null)
                 {
-                    var versionString = reg.GetValue("PowerShellVersion") as string;
+                    var versionString = reg.GetValue(Constants.PowerShellVersionRegKeyName) as string;
                     Version.TryParse(versionString, out version);
                     return version;
                 }

--- a/PowershellTools.Common/PowershellTools.Common.csproj
+++ b/PowershellTools.Common/PowershellTools.Common.csproj
@@ -96,6 +96,7 @@
   <ItemGroup>
     <Compile Include="Constants.cs" />
     <Compile Include="Debugging\DebugEngineConstants.cs" />
+    <Compile Include="DependencyUtilities.cs" />
     <Compile Include="IntelliSense\CommandCompletionHelper.cs" />
     <Compile Include="IntelliSense\EmptyScriptExtent.cs" />
     <Compile Include="IntelliSense\EmptyScriptPosition.cs" />

--- a/PowershellTools.Common/ServiceManagement/DebuggingContract/IPowershellDebuggingService.cs
+++ b/PowershellTools.Common/ServiceManagement/DebuggingContract/IPowershellDebuggingService.cs
@@ -35,6 +35,9 @@ namespace PowerShellTools.Common.ServiceManagement.DebuggingContract
         string ExecuteDebuggingCommandOutNull(string cmdline);
 
         [OperationContract]
+        void SetDebuggerResumeAction(DebuggerResumeAction resumeAction);
+
+        [OperationContract]
         void Stop();
 
         [OperationContract]

--- a/PowershellTools.HostService/PowershellTools.HostService.csproj
+++ b/PowershellTools.HostService/PowershellTools.HostService.csproj
@@ -119,7 +119,7 @@
     <Compile Include="ServiceManagement\Debugging\PowerShellDebuggingService.cs" />
     <Compile Include="ServiceManagement\Debugging\PowerShellDebuggingServiceEventHandlers.cs" />
     <Compile Include="ServiceManagement\Debugging\PowerShellDebuggingServiceUtilities.cs" />
-    <Compile Include="ServiceManagement\Debugging\PowerShellDebuggingServiceUtilities30.cs" />
+    <Compile Include="ServiceManagement\Debugging\PowerShellDebuggingServiceUtilities40.cs" />
     <Compile Include="ServiceManagement\Debugging\PowerShellHost.cs" />
     <Compile Include="ServiceManagement\Debugging\PowerShellServiceHost.cs" />
     <Compile Include="ServiceManagement\IntelliSense\PowerShellIntelliSenseService.cs" />

--- a/PowershellTools.HostService/PowershellTools.HostService.csproj
+++ b/PowershellTools.HostService/PowershellTools.HostService.csproj
@@ -119,6 +119,7 @@
     <Compile Include="ServiceManagement\Debugging\PowerShellDebuggingService.cs" />
     <Compile Include="ServiceManagement\Debugging\PowerShellDebuggingServiceEventHandlers.cs" />
     <Compile Include="ServiceManagement\Debugging\PowerShellDebuggingServiceUtilities.cs" />
+    <Compile Include="ServiceManagement\Debugging\PowerShellDebuggingServiceUtilities30.cs" />
     <Compile Include="ServiceManagement\Debugging\PowerShellHost.cs" />
     <Compile Include="ServiceManagement\Debugging\PowerShellServiceHost.cs" />
     <Compile Include="ServiceManagement\IntelliSense\PowerShellIntelliSenseService.cs" />

--- a/PowershellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingService.cs
+++ b/PowershellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingService.cs
@@ -46,7 +46,7 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
         private bool _debugOutput;
         private static readonly Regex _rgx = new Regex(DebugEngineConstants.ExecutionCommandFileReplacePattern);
         private DebuggerResumeAction _resumeAction;
-        private Version _installedPowershellVersion;
+        private Version _installedPowerShellVersion;
 
         /// <summary>
         /// Minimal powershell version required for remote session debugging
@@ -63,7 +63,7 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
             _mapRemoteToLocal = new Dictionary<string, string>();
             _psBreakpointTable = new List<PowerShellBreakpointRecord>();
             _debugOutput = true;
-            _installedPowershellVersion = DependencyUtilities.GetInstalledPowerShellVersion();
+            _installedPowerShellVersion = DependencyUtilities.GetInstalledPowerShellVersion();
             InitializeRunspace(this);
         }
 

--- a/PowershellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingService.cs
+++ b/PowershellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingService.cs
@@ -20,6 +20,7 @@ using System.Text.RegularExpressions;
 using PowerShellTools.Common.Debugging;
 using System.Diagnostics;
 using PowerShellTools.Common.IntelliSense;
+using PowerShellTools.Common;
 
 namespace PowerShellTools.HostService.ServiceManagement.Debugging
 {
@@ -45,6 +46,12 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
         private bool _debugOutput;
         private static readonly Regex _rgx = new Regex(DebugEngineConstants.ExecutionCommandFileReplacePattern);
         private DebuggerResumeAction _resumeAction;
+        private Version _installedPowershellVersion;
+
+        /// <summary>
+        /// Minimal powershell version required for remote session debugging
+        /// </summary>
+        private static readonly Version RequiredPowerShellVersionForRemoteSessionDebugging = new Version(4, 0);
 
         public PowerShellDebuggingService()
         {
@@ -56,6 +63,7 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
             _mapRemoteToLocal = new Dictionary<string, string>();
             _psBreakpointTable = new List<PowerShellBreakpointRecord>();
             _debugOutput = true;
+            _installedPowershellVersion = DependencyUtilities.GetInstalledPowerShellVersion();
             InitializeRunspace(this);
         }
 

--- a/PowershellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingService.cs
+++ b/PowershellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingService.cs
@@ -358,6 +358,12 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
 
                 return !error;
             }
+            catch (TypeLoadException ex)
+            {
+                ServiceCommon.Log("Type,  Exception: {0}", ex.Message);
+                OnTerminatingException(ex);
+                return false;
+            }
             catch (Exception ex)
             {
                 ServiceCommon.Log("Terminating error,  Exception: {0}", ex.Message);

--- a/PowershellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingService.cs
+++ b/PowershellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingService.cs
@@ -44,6 +44,7 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
         private string _debugCommandOutput;
         private bool _debugOutput;
         private static readonly Regex _rgx = new Regex(DebugEngineConstants.ExecutionCommandFileReplacePattern);
+        private DebuggerResumeAction _resumeAction;
 
         public PowerShellDebuggingService()
         {
@@ -351,10 +352,7 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
                     _currentPowerShell.AddCommand("out-default");
                     _currentPowerShell.Commands.Commands[0].MergeMyResults(PipelineResultTypes.Error, PipelineResultTypes.Output);
 
-                    var objects = new PSDataCollection<PSObject>();
-                    objects.DataAdded += objects_DataAdded;
-
-                    _currentPowerShell.Invoke(null, objects);
+                    _currentPowerShell.Invoke();
                     error = _currentPowerShell.HadErrors;
                 }
 
@@ -662,6 +660,18 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
                 }
 
                 return prompt;
+            }
+        }
+
+
+
+        public void SetDebuggerResumeAction(DebuggerResumeAction resumeAction)
+        {
+            lock (_executeDebugCommandLock)
+            {
+                ServiceCommon.Log("Client asks for resuming debugger");
+                _resumeAction = resumeAction;
+                _pausedEvent.Set();
             }
         }
 

--- a/PowershellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingService.cs
+++ b/PowershellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingService.cs
@@ -663,8 +663,10 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
             }
         }
 
-
-
+        /// <summary>
+        /// Client set resume action for debugger
+        /// </summary>
+        /// <param name="resumeAction">DebuggerResumeAction</param>
         public void SetDebuggerResumeAction(DebuggerResumeAction resumeAction)
         {
             lock (_executeDebugCommandLock)

--- a/PowershellTools.HostService/ServiceManagement/Debugging/PowershellServiceHost.cs
+++ b/PowershellTools.HostService/ServiceManagement/Debugging/PowershellServiceHost.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Reflection;
 using System.Diagnostics;
+using PowerShellTools.Common;
 
 namespace PowerShellTools.HostService.ServiceManagement.Debugging
 {
@@ -25,6 +26,11 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
         /// A reference to the runspace used to start an interactive session.
         /// </summary>
         private Runspace _pushedRunspace = null;
+
+        /// <summary>
+        /// Minimal powershell version required for remote session debugging
+        /// </summary>
+        private static readonly Version RequiredPowerShellVersionForRemoteSessionDebugging = new Version(4, 0);
 
         /// <summary>
         /// Gets a string that contains the name of this host implementation. 
@@ -182,7 +188,18 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
         {
             _pushedRunspace = Runspace;
             Runspace = runspace;
-            Runspace.Debugger.SetDebugMode(DebugModes.RemoteScript);
+
+            ServiceCommon.Log("entering...");
+            if (DependencyUtilities.GetInstalledPowerShellVersion() < RequiredPowerShellVersionForRemoteSessionDebugging)
+            {
+                ServiceCommon.Log("version failed...");
+                _callback.OutputStringLine(Resources.Warning_HigherVersionRequiredForDebugging);
+            }
+            else
+            {
+                Runspace.Debugger.SetDebugMode(DebugModes.RemoteScript);
+            }
+            ServiceCommon.Log("exits...");
             _callback.SetRemoteRunspace(true);
 
             RegisterRemoteFileOpenEvent(runspace);

--- a/PowershellTools.HostService/ServiceManagement/Debugging/PowershellServiceHost.cs
+++ b/PowershellTools.HostService/ServiceManagement/Debugging/PowershellServiceHost.cs
@@ -28,11 +28,6 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
         private Runspace _pushedRunspace = null;
 
         /// <summary>
-        /// Minimal powershell version required for remote session debugging
-        /// </summary>
-        private static readonly Version RequiredPowerShellVersionForRemoteSessionDebugging = new Version(4, 0);
-
-        /// <summary>
         /// Gets a string that contains the name of this host implementation. 
         /// Keep in mind that this string may be used by script writers to
         /// identify when your host is being used.
@@ -189,17 +184,15 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
             _pushedRunspace = Runspace;
             Runspace = runspace;
 
-            ServiceCommon.Log("entering...");
-            if (DependencyUtilities.GetInstalledPowerShellVersion() < RequiredPowerShellVersionForRemoteSessionDebugging)
+            if (_installedPowershellVersion < RequiredPowerShellVersionForRemoteSessionDebugging)
             {
-                ServiceCommon.Log("version failed...");
                 _callback.OutputStringLine(Resources.Warning_HigherVersionRequiredForDebugging);
             }
             else
             {
-                Runspace.Debugger.SetDebugMode(DebugModes.RemoteScript);
+                SetRemoteScriptDebugMode40(Runspace);
             }
-            ServiceCommon.Log("exits...");
+
             _callback.SetRemoteRunspace(true);
 
             RegisterRemoteFileOpenEvent(runspace);

--- a/PowershellTools.HostService/ServiceManagement/Debugging/PowershellServiceHost.cs
+++ b/PowershellTools.HostService/ServiceManagement/Debugging/PowershellServiceHost.cs
@@ -184,7 +184,7 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
             _pushedRunspace = Runspace;
             Runspace = runspace;
 
-            if (_installedPowershellVersion < RequiredPowerShellVersionForRemoteSessionDebugging)
+            if (_installedPowerShellVersion < RequiredPowerShellVersionForRemoteSessionDebugging)
             {
                 _callback.OutputStringLine(Resources.Warning_HigherVersionRequiredForDebugging);
             }


### PR DESCRIPTION
Adamdriscoll#214

@AndreSayreMSFT @HuanhuanSunMSFT @adamdriscoll  @Microsoft/poshtools 
Some of the new feature we added in PoshTools is utilizing some v4.0+ powershell. This change is adding a bunch of version specific logics to handle different cases like:
1. Debugging command typed during debug break on v3 install 
2. Debugging command typed during debug break on v4 install 
3. Remote session debugging try on v3 install --> not supported, give a warning message when people entering PS remote session.
4. Remote session debugging try on v4+ install --> supported
