### PR TITLE
Fix REPL command execution issue #397,#398

### DIFF
--- a/PowerShellTools/DebugEngine/ScriptDebugger.cs
+++ b/PowerShellTools/DebugEngine/ScriptDebugger.cs
@@ -325,13 +325,13 @@ namespace PowerShellTools.DebugEngine
             try
             {
                 bool timedOut = false;
-                System.Timers.Timer aTimer = new System.Timers.Timer(1000); // 1 second timeout
+                System.Timers.Timer aTimer = new System.Timers.Timer(30000); // 30 seconds timeout
                 aTimer.Elapsed += (sender, args) => { timedOut = true; };
 
                 while (DebuggingService.GetRunspaceAvailability() != RunspaceAvailability.Available
                     && !timedOut)
                 {
-                    Thread.Sleep(50);
+                    Thread.Sleep(50); // polling every 50 milliseconds
                 }
 
                 if (timedOut)
@@ -353,11 +353,6 @@ namespace PowerShellTools.DebugEngine
             {
                 DebuggerFinished();
             }
-        }
-
-        private void OnTimedEvent(object sender, System.Timers.ElapsedEventArgs e)
-        {
-            throw new NotImplementedException();
         }
 
         /// <summary>


### PR DESCRIPTION
#397  #398

@AndreSayreMSFT @HuanhuanSunMSFT @Microsoft/poshtools 

For case where user type "cd<enter>" really fast, you can run into the situation where intellisense triggered a bit of ahead of execution request, so that the execution got busy pipeline error. Considering there is no proper way to stop/cancel triggered intellisense request, we'll let the execution engine to wait for 1 second max for the runspace got free up.
