### PR TITLE
Fix an completion selection issue

### DIFF
--- a/PowerShellTools/Intellisense/PowerShellCompletionSource.cs
+++ b/PowerShellTools/Intellisense/PowerShellCompletionSource.cs
@@ -161,7 +161,7 @@ namespace PowerShellTools.Intellisense
             {
 		foreach (var current in Completions)
 		{
-		    if (current.InsertionText.StartsWith(InitialApplicableTo, StringComparison.OrdinalIgnoreCase))
+		    if (current.DisplayText.StartsWith(InitialApplicableTo, StringComparison.OrdinalIgnoreCase))
 		    {
 			SelectionStatus = new CompletionSelectionStatus(current, true, true);
 			return;


### PR DESCRIPTION
To keep parity with ISE, they filter the best match using DisplayText instead of InsertionText.
@AndreSayreMSFT @EricMSFT @Microsoft/poshtools 
