### PR TITLE
Fix #397: race condition between intellisense and execution.

### DIFF
--- a/PowerShellTools.HostService/ServiceCommon.cs
+++ b/PowerShellTools.HostService/ServiceCommon.cs
@@ -16,6 +16,7 @@ namespace PowerShellTools.HostService
 {
     public class ServiceCommon
     {
+        public static object RunspaceLock = new object();
 
         /// <summary>
         /// TODO: Temporary logging before having logging infrastructure ready

--- a/PowerShellTools.HostService/ServiceManagement/IntelliSense/PowershellIntelliSenseService.cs
+++ b/PowerShellTools.HostService/ServiceManagement/IntelliSense/PowershellIntelliSenseService.cs
@@ -4,6 +4,7 @@ using PowerShellTools.HostService.ServiceManagement.Debugging;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Management.Automation;
 using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
 using System.ServiceModel;
@@ -47,7 +48,11 @@ namespace PowerShellTools.HostService.ServiceManagement
                     {
                         try
                         {
-                            var commandCompletion = CommandCompletionHelper.GetCommandCompletionList(_script, _caretPosition, _runspace);
+                            CommandCompletion commandCompletion;
+                            lock (ServiceCommon.RunspaceLock)
+                            {
+                                commandCompletion = CommandCompletionHelper.GetCommandCompletionList(_script, _caretPosition, _runspace);
+                            }
                             ServiceCommon.LogCallbackEvent("Callback intellisense at position {0}", _caretPosition);
                             _callback.PushCompletionResult(CompletionResultList.FromCommandCompletion(commandCompletion));
 

--- a/PowerShellTools.HostService/ServiceManagement/IntelliSense/PowershellIntelliSenseService.cs
+++ b/PowerShellTools.HostService/ServiceManagement/IntelliSense/PowershellIntelliSenseService.cs
@@ -48,7 +48,7 @@ namespace PowerShellTools.HostService.ServiceManagement
                     {
                         try
                         {
-                            CommandCompletion commandCompletion;
+                            CommandCompletion commandCompletion = null;
                             lock (ServiceCommon.RunspaceLock)
                             {
                                 commandCompletion = CommandCompletionHelper.GetCommandCompletionList(_script, _caretPosition, _runspace);

--- a/PowerShellTools/DebugEngine/ScriptDebugger.cs
+++ b/PowerShellTools/DebugEngine/ScriptDebugger.cs
@@ -324,23 +324,6 @@ namespace PowerShellTools.DebugEngine
 
             try
             {
-                bool timedOut = false;
-                System.Timers.Timer aTimer = new System.Timers.Timer(30000); // 30 seconds timeout
-                aTimer.Elapsed += (sender, args) => { timedOut = true; };
-
-                while (DebuggingService.GetRunspaceAvailability() != RunspaceAvailability.Available
-                    && !timedOut)
-                {
-                    Thread.Sleep(50); // polling every 50 milliseconds
-                }
-
-                if (timedOut)
-                {
-                    HostUi.VsOutputString(Resources.ErrorPipelineBusy);
-
-                    return false;
-                }
-
                 return ExecuteInternal(commandLine);
             }
             catch (Exception ex)

--- a/PowerShellTools/Intellisense/IntelliSenseManager.cs
+++ b/PowerShellTools/Intellisense/IntelliSenseManager.cs
@@ -472,11 +472,6 @@ namespace PowerShellTools.Intellisense
                     catch (Exception ex)
                     {
                         Log.Debug("Failed to process completion results. Exception: " + ex);
-
-                        if (_statusBar != null)
-                        {
-                            _statusBar.SetText(String.Format("Failed to process completion results in {0:0.00} seconds...", _sw.Elapsed.TotalSeconds));
-                        }
                     }
                 });
         }

--- a/PowershellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingService.cs
+++ b/PowershellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingService.cs
@@ -349,16 +349,19 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
                     }
                 }
 
-                using (_currentPowerShell = PowerShell.Create())
+                lock (ServiceCommon.RunspaceLock)
                 {
-                    _currentPowerShell.Runspace = _runspace;
-                    _currentPowerShell.AddScript(commandLine);
+                    using (_currentPowerShell = PowerShell.Create())
+                    {
+                        _currentPowerShell.Runspace = _runspace;
+                        _currentPowerShell.AddScript(commandLine);
 
-                    _currentPowerShell.AddCommand("out-default");
-                    _currentPowerShell.Commands.Commands[0].MergeMyResults(PipelineResultTypes.Error, PipelineResultTypes.Output);
+                        _currentPowerShell.AddCommand("out-default");
+                        _currentPowerShell.Commands.Commands[0].MergeMyResults(PipelineResultTypes.Error, PipelineResultTypes.Output);
 
-                    _currentPowerShell.Invoke();
-                    error = _currentPowerShell.HadErrors;
+                        _currentPowerShell.Invoke();
+                        error = _currentPowerShell.HadErrors;
+                    }
                 }
 
                 return !error;


### PR DESCRIPTION
Fix #397 

Description: even we do check the runspace availability, it still could run into race condition on busy pipeline, so apply a lock between the two to avoid any further conflict.

@AndreSayreMSFT @HuanhuanSunMSFT @Microsoft/poshtools 
