### PR TITLE
Bugfix for #346, #348 and #476

### DIFF
--- a/PowerShellTools.Test/IntelliSense/CommentAreaUnitTests.cs
+++ b/PowerShellTools.Test/IntelliSense/CommentAreaUnitTests.cs
@@ -83,17 +83,19 @@ namespace PowerShellTools.Test.IntelliSense
             Parser.ParseInput(script, out tokens, out errors);
 
             Mock<ITextBuffer> textBuffer = new Mock<ITextBuffer>();
-            TextBufferMockHelper(textBuffer, tokens);
+            TextBufferMockHelper(textBuffer, script, tokens);
             bool actual = Utilities.IsInCommentArea(caretPosition, textBuffer.Object);
 
             Assert.AreEqual(expected, actual);
         }
 
-        private void TextBufferMockHelper(Mock<ITextBuffer> textBuffer, Token[] tokens)
+        private void TextBufferMockHelper(Mock<ITextBuffer> textBuffer, string script, Token[] tokens)
         {
             PropertyCollection pc = new PropertyCollection();
             pc.AddProperty(BufferProperties.Tokens, tokens);
             textBuffer.Setup(m => m.Properties).Returns(pc);
+            textBuffer.Setup(m => m.CurrentSnapshot.Length)
+                      .Returns(() => script.Length);
         }
     }
 }

--- a/PowerShellTools/Intellisense/IntelliSenseManager.cs
+++ b/PowerShellTools/Intellisense/IntelliSenseManager.cs
@@ -239,6 +239,7 @@ namespace PowerShellTools.Intellisense
                 }
             }
 
+            bool justCommitIntelliSense = false;
             if (IsIntelliSenseTriggerDot(typedChar) && _activeSession != null && !_activeSession.IsDismissed)
             {
                 var selectionStatus = _activeSession.SelectedCompletionSet.SelectionStatus;
@@ -269,6 +270,7 @@ namespace PowerShellTools.Intellisense
 
                     Log.Debug("Commit");
                     _activeSession.Commit();
+                    justCommitIntelliSense = true;
                 }
                 else
                 {
@@ -299,7 +301,7 @@ namespace PowerShellTools.Intellisense
             bool handled = false;
 
             if (IsIntellisenseTrigger(typedChar) ||
-                (IsIntelliSenseTriggerDot(typedChar) && IsPreviousTokenVariable()) || // If previous token before a dot was a variable, trigger intellisense
+                (justCommitIntelliSense || (IsIntelliSenseTriggerDot(typedChar) && IsPreviousTokenVariable())) || // If dot just commit a session or previous token before a dot was a variable, trigger intellisense
                 (char.IsWhiteSpace(typedChar) && IsPreviousTokenParameter())) // If the previous token before a space was a parameter, trigger intellisense
             {
                 TriggerCompletion();

--- a/PowerShellTools/Intellisense/Utilities.cs
+++ b/PowerShellTools/Intellisense/Utilities.cs
@@ -86,6 +86,11 @@ namespace PowerShellTools.Intellisense
             }
         }
 
+        /// <summary>
+        /// Determines if caret is in comment area.
+        /// </summary>
+        /// <param name="textView">Current text view.</param>
+        /// <returns>True if caret is in comment area. Otherwise, false.</returns>
         internal static bool IsCaretInCommentArea(ITextView textView)
         {
             ITextBuffer currentActiveBuffer;
@@ -97,6 +102,15 @@ namespace PowerShellTools.Intellisense
             return Utilities.IsInCommentArea(currentPosition, currentActiveBuffer);
         }
 
+        /// <summary>
+        /// Get current caret position on a PowerShell textbuffer. If current top text buffer is of type PowerShell, then directly return caret postion.
+        /// If current top text buffer is of type REPL, we need to map caret position from REPL text buffer to last PowerShell text buffer and return it. 
+        /// If such a mapping doesn't exist, then return -1.
+        /// If current top text buffer is neither PowerShell or REPL, we don't deal with it. Just return -1.
+        /// </summary>
+        /// <param name="textView">The current text view</param>
+        /// <param name="currentActiveBuffer">Get the active buffer the caret is on.</param>
+        /// <returns>Return the right caret position in a PowerShell text buffer or -1 if none is found.</returns>
         internal static int GetCurrentBufferPosition(ITextView textView, out ITextBuffer currentActiveBuffer)
         {
             int currentBufferPosition;
@@ -105,7 +119,7 @@ namespace PowerShellTools.Intellisense
                 currentActiveBuffer = textView.TextBuffer;
                 currentBufferPosition = textView.Caret.Position.BufferPosition.Position;
             }
-            // If in the REPL window, the current textbuffer won't work, so we have to get the last PowerShellLanguage buffer
+            // If in the REPL window, the current textbuffer won't work, so we have to get the last PowerShell buffer
             else if (textView.TextBuffer.ContentType.TypeName.Equals(ReplConstants.ReplContentTypeName, StringComparison.Ordinal))
             {
                 currentActiveBuffer = textView.BufferGraph.GetTextBuffers(p => p.ContentType.TypeName.Equals(PowerShellConstants.LanguageName, StringComparison.Ordinal))
@@ -150,6 +164,7 @@ namespace PowerShellTools.Intellisense
         {
             return IsInCertainPSTokenTypesArea(position, buffer, PSTokenType.Variable, PSTokenType.Member);
         }
+
         private static bool IsInCertainPSTokenTypesArea(int position, ITextBuffer buffer, params PSTokenType[] selectedPSTokenTypes)
         {
             if (position < 0 || position > buffer.CurrentSnapshot.Length)


### PR DESCRIPTION
Regarding normal path completion, keep parity with ISE. 
For path completion between double quotes, we support filtering, which surpasses ISE:)
@AndreSayreMSFT @EricJizbaMSFT @EricMSFT @Microsoft/poshtools 
