### PR TITLE
Bug607 - Fixing typo in "Execute as Script with Parameters"

### DIFF
--- a/PowerShellTools/PowerShellTools.vsct
+++ b/PowerShellTools/PowerShellTools.vsct
@@ -55,7 +55,7 @@
         <Strings>
           <LocCanonicalName>PowerShell.ExecuteAsScript</LocCanonicalName>
           <CanonicalName>PowerShell.ExecuteAsScript</CanonicalName>
-          <ButtonText>Execute as Script With Paramters</ButtonText>
+          <ButtonText>Execute as Script with Parameters</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidPoshToolsCmdSet" id="cmdidExecuteAsScriptSolution"
@@ -77,7 +77,7 @@
         <Strings>
           <LocCanonicalName>PowerShell.ExecuteAsScript</LocCanonicalName>
           <CanonicalName>PowerShell.ExecuteAsScript</CanonicalName>
-          <ButtonText>Execute as Script With Paramters</ButtonText>
+          <ButtonText>Execute as Script with Parameters</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidPoshToolsCmdSet" id="cmdidExecuteSelection"


### PR DESCRIPTION
Two places to fix.  One in the context menu of the editor. The other in the solution explorer context menu.
