### PR TITLE
Using existing ComponentModel instead of creating a new one

### DIFF
--- a/PowerShellTools/LanguageService/PowerShellLanaguagePreferences.cs
+++ b/PowerShellTools/LanguageService/PowerShellLanaguagePreferences.cs
@@ -5,61 +5,61 @@ namespace PowerShellTools.LanguageService
 {
     internal sealed class PowerShellLanguagePreferences : IVsTextManagerEvents2
     {
-	LANGPREFERENCES _preferences;
+        LANGPREFERENCES _preferences;
 
-	public PowerShellLanguagePreferences(LANGPREFERENCES preferences)
-	{
-	    _preferences = preferences;
-	}
+        public PowerShellLanguagePreferences(LANGPREFERENCES preferences)
+        {
+            _preferences = preferences;
+        }
 
-	#region IVsTextManagerEvents2 Implementation
+        #region IVsTextManagerEvents2 Implementation
 
-	public int OnRegisterMarkerType(int iMarkerType)
-	{
-	    return VSConstants.S_OK;
-	}
+        public int OnRegisterMarkerType(int iMarkerType)
+        {
+            return VSConstants.S_OK;
+        }
 
-	public int OnRegisterView(IVsTextView pView)
-	{
-	    return VSConstants.S_OK;
-	}
+        public int OnRegisterView(IVsTextView pView)
+        {
+            return VSConstants.S_OK;
+        }
 
-	public int OnReplaceAllInFilesBegin()
-	{
-	    return VSConstants.S_OK;
-	}
+        public int OnReplaceAllInFilesBegin()
+        {
+            return VSConstants.S_OK;
+        }
 
-	public int OnReplaceAllInFilesEnd()
-	{
-	    return VSConstants.S_OK;
-	}
+        public int OnReplaceAllInFilesEnd()
+        {
+            return VSConstants.S_OK;
+        }
 
-	public int OnUnregisterView(IVsTextView pView)
-	{
-	    return VSConstants.S_OK;
-	}
+        public int OnUnregisterView(IVsTextView pView)
+        {
+            return VSConstants.S_OK;
+        }
 
-	public int OnUserPreferencesChanged2(VIEWPREFERENCES2[] pviewPrefs, FRAMEPREFERENCES2[] pframePrefs, LANGPREFERENCES2[] plangPrefs, FONTCOLORPREFERENCES2[] pcolorPrefs)
-	{
-	    if (plangPrefs != null && plangPrefs.Length > 0 && plangPrefs[0].guidLang == _preferences.guidLang)
-	    {
-		_preferences.IndentStyle = plangPrefs[0].IndentStyle;
-	    }
-	    return VSConstants.S_OK;
-	}
+        public int OnUserPreferencesChanged2(VIEWPREFERENCES2[] pviewPrefs, FRAMEPREFERENCES2[] pframePrefs, LANGPREFERENCES2[] plangPrefs, FONTCOLORPREFERENCES2[] pcolorPrefs)
+        {
+            if (plangPrefs != null && plangPrefs.Length > 0 && plangPrefs[0].guidLang == _preferences.guidLang)
+            {
+                _preferences.IndentStyle = plangPrefs[0].IndentStyle;
+            }
+            return VSConstants.S_OK;
+        }
 
-	#endregion
+        #endregion
 
-	#region Options Supported in Tools\Options\TextEditor\PowerShell
+        #region Options Supported in Tools\Options\TextEditor\PowerShell
 
-	public vsIndentStyle IndentMode
-	{
-	    get
-	    {
-		return _preferences.IndentStyle;
-	    }
-	}
+        public vsIndentStyle IndentMode
+        {
+            get
+            {
+                return _preferences.IndentStyle;
+            }
+        }
 
-	#endregion
+        #endregion
     }
 }

--- a/PowerShellTools/LanguageService/PowerShellLanguageInfo.cs
+++ b/PowerShellTools/LanguageService/PowerShellLanguageInfo.cs
@@ -19,158 +19,158 @@ namespace PowerShellTools.LanguageService
     [Guid("1C4711F1-3766-4F84-9516-43FA4169CC36")]
     internal sealed class PowerShellLanguageInfo : IVsLanguageInfo, IVsLanguageDebugInfo
     {
-	private readonly IServiceContainer _serviceContainer;
-	private readonly IComponentModel _componentModel;
-	private PowerShellLanguagePreferences _langPrefs;
+        private readonly IServiceContainer _serviceContainer;
+        private readonly IComponentModel _componentModel;
+        private PowerShellLanguagePreferences _langPrefs;
 
-	public PowerShellLanguageInfo(IServiceContainer serviceContainer)
-	{
-	    _serviceContainer = serviceContainer;
-	    _componentModel = serviceContainer.GetService(typeof(SComponentModel)) as IComponentModel;
+        public PowerShellLanguageInfo(IServiceContainer serviceContainer)
+        {
+            _serviceContainer = serviceContainer;
+            _componentModel = serviceContainer.GetService(typeof(SComponentModel)) as IComponentModel;
 
-	    IVsTextManager textMgr = (IVsTextManager)serviceContainer.GetService(typeof(SVsTextManager));
-	    if (textMgr != null)
-	    {
-		// Load the initial settings
-		var langPrefs = new LANGPREFERENCES[1];
-		langPrefs[0].guidLang = typeof(PowerShellLanguageInfo).GUID;
-		ErrorHandler.ThrowOnFailure(textMgr.GetUserPreferences(null, null, langPrefs, null));
-		_langPrefs = new PowerShellLanguagePreferences(langPrefs[0]);
+            IVsTextManager textMgr = (IVsTextManager)serviceContainer.GetService(typeof(SVsTextManager));
+            if (textMgr != null)
+            {
+                // Load the initial settings
+                var langPrefs = new LANGPREFERENCES[1];
+                langPrefs[0].guidLang = typeof(PowerShellLanguageInfo).GUID;
+                ErrorHandler.ThrowOnFailure(textMgr.GetUserPreferences(null, null, langPrefs, null));
+                _langPrefs = new PowerShellLanguagePreferences(langPrefs[0]);
 
-		// Hook up to the setting change
-		Guid guid = typeof(IVsTextManagerEvents2).GUID;
-		Microsoft.VisualStudio.OLE.Interop.IConnectionPoint connectionPoint;
-		((Microsoft.VisualStudio.OLE.Interop.IConnectionPointContainer)textMgr).FindConnectionPoint(ref guid, out connectionPoint);
-		uint cookie;
-		connectionPoint.Advise(_langPrefs, out cookie);
-	    }
-	}
+                // Hook up to the setting change
+                Guid guid = typeof(IVsTextManagerEvents2).GUID;
+                Microsoft.VisualStudio.OLE.Interop.IConnectionPoint connectionPoint;
+                ((Microsoft.VisualStudio.OLE.Interop.IConnectionPointContainer)textMgr).FindConnectionPoint(ref guid, out connectionPoint);
+                uint cookie;
+                connectionPoint.Advise(_langPrefs, out cookie);
+            }
+        }
 
-	public PowerShellLanguagePreferences LangPrefs
-	{
-	    get
-	    {
-		return _langPrefs;
-	    }
-	}
+        public PowerShellLanguagePreferences LangPrefs
+        {
+            get
+            {
+                return _langPrefs;
+            }
+        }
 
-	#region IVsLanguageInfo Implementation
+        #region IVsLanguageInfo Implementation
 
-	public int GetCodeWindowManager(IVsCodeWindow pCodeWin, out IVsCodeWindowManager ppCodeWinMgr)
-	{
-	    var model = _serviceContainer.GetService(typeof(SComponentModel)) as IComponentModel;
-	    var service = model.GetService<IVsEditorAdaptersFactoryService>();
+        public int GetCodeWindowManager(IVsCodeWindow pCodeWin, out IVsCodeWindowManager ppCodeWinMgr)
+        {
+            var model = _serviceContainer.GetService(typeof(SComponentModel)) as IComponentModel;
+            var service = model.GetService<IVsEditorAdaptersFactoryService>();
 
-        var statusBar = _serviceContainer.GetService(typeof(SVsStatusbar)) as IVsStatusbar;
+            var statusBar = _serviceContainer.GetService(typeof(SVsStatusbar)) as IVsStatusbar;
 
-	    IVsTextView textView;
-	    if (ErrorHandler.Succeeded(pCodeWin.GetPrimaryView(out textView)))
-	    {
-		ppCodeWinMgr = new CodeWindowManager(pCodeWin, service.GetWpfTextView(textView), statusBar);
-		return VSConstants.S_OK;
-	    }
+            IVsTextView textView;
+            if (ErrorHandler.Succeeded(pCodeWin.GetPrimaryView(out textView)))
+            {
+                ppCodeWinMgr = new CodeWindowManager(pCodeWin, service.GetWpfTextView(textView), statusBar);
+                return VSConstants.S_OK;
+            }
 
-	    ppCodeWinMgr = null;
-	    return VSConstants.E_FAIL;
-	}
+            ppCodeWinMgr = null;
+            return VSConstants.E_FAIL;
+        }
 
-	public int GetFileExtensions(out string pbstrExtensions)
-	{
-	    // This is the same extension the language service was
-	    // registered as supporting.
-	    pbstrExtensions = PowerShellConstants.PS1File + ";" + PowerShellConstants.PSD1File + ";" + PowerShellConstants.PSM1File;
-	    return VSConstants.S_OK;
-	}
+        public int GetFileExtensions(out string pbstrExtensions)
+        {
+            // This is the same extension the language service was
+            // registered as supporting.
+            pbstrExtensions = PowerShellConstants.PS1File + ";" + PowerShellConstants.PSD1File + ";" + PowerShellConstants.PSM1File;
+            return VSConstants.S_OK;
+        }
 
 
-	public int GetLanguageName(out string bstrName)
-	{
-	    // This is the same name the language service was registered with.
-	    bstrName = PowerShellConstants.LanguageName;
-	    return VSConstants.S_OK;
-	}
+        public int GetLanguageName(out string bstrName)
+        {
+            // This is the same name the language service was registered with.
+            bstrName = PowerShellConstants.LanguageName;
+            return VSConstants.S_OK;
+        }
 
-	/// <summary>
-	/// GetColorizer is not implemented because we implement colorization using the new managed APIs.
-	/// </summary>
-	public int GetColorizer(IVsTextLines pBuffer, out IVsColorizer ppColorizer)
-	{
-	    ppColorizer = null;
-	    return VSConstants.E_FAIL;
-	}
+        /// <summary>
+        /// GetColorizer is not implemented because we implement colorization using the new managed APIs.
+        /// </summary>
+        public int GetColorizer(IVsTextLines pBuffer, out IVsColorizer ppColorizer)
+        {
+            ppColorizer = null;
+            return VSConstants.E_FAIL;
+        }
 
-	#endregion
+        #endregion
 
-	#region IVsLanguageDebugInfo Members
+        #region IVsLanguageDebugInfo Members
 
-	public int GetLanguageID(IVsTextBuffer pBuffer, int iLine, int iCol, out Guid pguidLanguageID)
-	{
-	    pguidLanguageID = Guid.Empty;
-	    return VSConstants.S_OK;
-	}
+        public int GetLanguageID(IVsTextBuffer pBuffer, int iLine, int iCol, out Guid pguidLanguageID)
+        {
+            pguidLanguageID = Guid.Empty;
+            return VSConstants.S_OK;
+        }
 
-	public int GetLocationOfName(string pszName, out string pbstrMkDoc, TextSpan[] pspanLocation)
-	{
-	    pbstrMkDoc = null;
-	    return VSConstants.E_FAIL;
-	}
+        public int GetLocationOfName(string pszName, out string pbstrMkDoc, TextSpan[] pspanLocation)
+        {
+            pbstrMkDoc = null;
+            return VSConstants.E_FAIL;
+        }
 
-	public int GetNameOfLocation(IVsTextBuffer pBuffer, int iLine, int iCol, out string pbstrName, out int piLineOffset)
-	{
-	    var model = _serviceContainer.GetService(typeof(SComponentModel)) as IComponentModel;
-	    var service = model.GetService<IVsEditorAdaptersFactoryService>();
-	    var buffer = service.GetDataBuffer(pBuffer);
+        public int GetNameOfLocation(IVsTextBuffer pBuffer, int iLine, int iCol, out string pbstrName, out int piLineOffset)
+        {
+            var model = _serviceContainer.GetService(typeof(SComponentModel)) as IComponentModel;
+            var service = model.GetService<IVsEditorAdaptersFactoryService>();
+            var buffer = service.GetDataBuffer(pBuffer);
 
-	    pbstrName = "";
-	    piLineOffset = iCol;
-	    return VSConstants.E_FAIL;
-	}
+            pbstrName = "";
+            piLineOffset = iCol;
+            return VSConstants.E_FAIL;
+        }
 
-	public int GetProximityExpressions(IVsTextBuffer pBuffer, int iLine, int iCol, int cLines, out IVsEnumBSTR ppEnum)
-	{
-	    ppEnum = null;
-	    return VSConstants.E_FAIL;
-	}
+        public int GetProximityExpressions(IVsTextBuffer pBuffer, int iLine, int iCol, int cLines, out IVsEnumBSTR ppEnum)
+        {
+            ppEnum = null;
+            return VSConstants.E_FAIL;
+        }
 
-	public int IsMappedLocation(IVsTextBuffer pBuffer, int iLine, int iCol)
-	{
-	    return VSConstants.E_FAIL;
-	}
+        public int IsMappedLocation(IVsTextBuffer pBuffer, int iLine, int iCol)
+        {
+            return VSConstants.E_FAIL;
+        }
 
-	public int ResolveName(string pszName, uint dwFlags, out IVsEnumDebugName ppNames)
-	{
-	    /*if((((RESOLVENAMEFLAGS)dwFlags) & RESOLVENAMEFLAGS.RNF_BREAKPOINT) != 0) {
-		// TODO: This should go through the project/analysis and see if we can
-		// resolve the names...
-	    }*/
-	    ppNames = null;
-	    return VSConstants.E_FAIL;
-	}
+        public int ResolveName(string pszName, uint dwFlags, out IVsEnumDebugName ppNames)
+        {
+            /*if((((RESOLVENAMEFLAGS)dwFlags) & RESOLVENAMEFLAGS.RNF_BREAKPOINT) != 0) {
+            // TODO: This should go through the project/analysis and see if we can
+            // resolve the names...
+            }*/
+            ppNames = null;
+            return VSConstants.E_FAIL;
+        }
 
-	public int ValidateBreakpointLocation(IVsTextBuffer pBuffer, int iLine, int iCol, TextSpan[] pCodeSpan)
-	{
-	    // per the docs, even if we don't indend to validate, we need to set the span info:
-	    // http://msdn.microsoft.com/en-us/library/microsoft.visualstudio.textmanager.interop.ivslanguagedebuginfo.validatebreakpointlocation.aspx
-	    // 
-	    // Caution
-	    // Even if you do not intend to support the ValidateBreakpointLocation method but your 
-	    // language does support breakpoints, you must implement this method and return a span 
-	    // that contains the specified line and column; otherwise, breakpoints cannot be set 
-	    // anywhere except line 1. You can return E_NOTIMPL to indicate that you do not otherwise 
-	    // support this method but the span must always be set. The example shows how this can be done.
+        public int ValidateBreakpointLocation(IVsTextBuffer pBuffer, int iLine, int iCol, TextSpan[] pCodeSpan)
+        {
+            // per the docs, even if we don't indend to validate, we need to set the span info:
+            // http://msdn.microsoft.com/en-us/library/microsoft.visualstudio.textmanager.interop.ivslanguagedebuginfo.validatebreakpointlocation.aspx
+            // 
+            // Caution
+            // Even if you do not intend to support the ValidateBreakpointLocation method but your 
+            // language does support breakpoints, you must implement this method and return a span 
+            // that contains the specified line and column; otherwise, breakpoints cannot be set 
+            // anywhere except line 1. You can return E_NOTIMPL to indicate that you do not otherwise 
+            // support this method but the span must always be set. The example shows how this can be done.
 
-	    // http://pytools.codeplex.com/workitem/787
-	    // We were previously returning S_OK here indicating to VS that we have in fact validated
-	    // the breakpoint.  Validating breakpoints actually interacts and effectively disables
-	    // the "Highlight entire source line for breakpoints and current statement" option as instead
-	    // VS highlights the validated region.  So we return E_NOTIMPL here to indicate that we have 
-	    // not validated the breakpoint, and then VS will happily respect the option when we're in 
-	    // design mode.
-	    pCodeSpan[0].iStartLine = iLine;
-	    pCodeSpan[0].iEndLine = iLine;
-	    return VSConstants.E_NOTIMPL;
-	}
+            // http://pytools.codeplex.com/workitem/787
+            // We were previously returning S_OK here indicating to VS that we have in fact validated
+            // the breakpoint.  Validating breakpoints actually interacts and effectively disables
+            // the "Highlight entire source line for breakpoints and current statement" option as instead
+            // VS highlights the validated region.  So we return E_NOTIMPL here to indicate that we have 
+            // not validated the breakpoint, and then VS will happily respect the option when we're in 
+            // design mode.
+            pCodeSpan[0].iStartLine = iLine;
+            pCodeSpan[0].iEndLine = iLine;
+            return VSConstants.E_NOTIMPL;
+        }
 
-	#endregion
+        #endregion
     }
 }

--- a/PowerShellTools/PowerShellToolsPackage.cs
+++ b/PowerShellTools/PowerShellToolsPackage.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Windows;
 using log4net;
 using Microsoft;
-using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -269,10 +268,9 @@ namespace PowerShellTools
             var langService = new PowerShellLanguageInfo(this);
             ((IServiceContainer)this).AddService(langService.GetType(), langService, true);
 
-            var componentModel = (IComponentModel)GetGlobalService(typeof(SComponentModel));
-            _textBufferFactoryService = componentModel.GetService<ITextBufferFactoryService>();
-            EditorImports.ClassificationTypeRegistryService = componentModel.GetService<IClassificationTypeRegistryService>();
-            EditorImports.ClassificationFormatMap = componentModel.GetService<IClassificationFormatMapService>();
+            _textBufferFactoryService = ComponentModel.GetService<ITextBufferFactoryService>();
+            EditorImports.ClassificationTypeRegistryService = ComponentModel.GetService<IClassificationTypeRegistryService>();
+            EditorImports.ClassificationFormatMap = ComponentModel.GetService<IClassificationFormatMapService>();
 
             if (_textBufferFactoryService != null)
             {
@@ -280,7 +278,7 @@ namespace PowerShellTools
             }
 
             var textManager = (IVsTextManager)GetService(typeof(SVsTextManager));
-            var adaptersFactory = componentModel.GetService<IVsEditorAdaptersFactoryService>();
+            var adaptersFactory = ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
 
             RefreshCommands(new ExecuteSelectionCommand(this.DependencyValidator),
                             new ExecuteFromEditorContextMenuCommand(this.DependencyValidator),


### PR DESCRIPTION
This is more of little refactoring than a fix to bug #602. 
As there is actually not much difference between using SComponent and import regarding getting a MEF component service. If the assembly itself has been marked as a mefcomponent, then it will be put into the default MEF component container of VS. However, if the class in this assembly is not a MEF type, i.e., not marked as Export, then we need to satisfy any imports in the class ourselves. By satisfy, I mean we need notify VS MEF component that we need import some mef components so that it will be able to recognize the import attributes. How to satisfy? using SComponent.DefaultCompositionService.SatisfyImportOnce(this) and the import will succeed. To conclude, using import still needs SComponent. It's just syntax sugar.
@AndreSayreMSFT @jinglou- 
