### PR TITLE
Local Running Broken Fix & Re-Enable Local Attach

### DIFF
--- a/PowerShellTools/DebugEngine/ScriptDebugProcess.cs
+++ b/PowerShellTools/DebugEngine/ScriptDebugProcess.cs
@@ -113,9 +113,20 @@ namespace PowerShellTools.DebugEngine
         public int GetPhysicalProcessId(AD_PROCESS_ID[] pProcessId)
         {
             Log.Debug("Process: GetPhysicalProcessId");
-
             var pidStruct = new AD_PROCESS_ID();
-            pidStruct.dwProcessId = (uint)ProcessId;
+
+            // if dealing with an actual process we need to identify it with its PID
+            if(ProcessId != 0)
+            {
+                pidStruct.dwProcessId = (uint)ProcessId;
+                pidStruct.ProcessIdType = (uint)enum_AD_PROCESS_ID.AD_PROCESS_ID_SYSTEM;
+            }
+            else
+            {
+                pidStruct.guidProcessId = Id;
+                pidStruct.ProcessIdType = (uint)enum_AD_PROCESS_ID.AD_PROCESS_ID_GUID;
+            }
+            
             pProcessId[0] = pidStruct;
 
             return VSConstants.S_OK;

--- a/PowerShellTools/DebugEngine/ScriptProgramProvider.cs
+++ b/PowerShellTools/DebugEngine/ScriptProgramProvider.cs
@@ -23,7 +23,7 @@ namespace PowerShellTools.DebugEngine
         public int GetProviderProcessData(enum_PROVIDER_FLAGS Flags, IDebugDefaultPort2 pPort, AD_PROCESS_ID ProcessId, CONST_GUID_ARRAY EngineFilter, PROVIDER_PROCESS_DATA[] pProcess)
         {
             Log.Debug("ProgramProvider: GetProviderProcessData");
-            /*
+            
             try
             {
                 if (Flags.HasFlag(enum_PROVIDER_FLAGS.PFLAG_GET_PROGRAM_NODES))
@@ -47,7 +47,7 @@ namespace PowerShellTools.DebugEngine
             {
                 Log.Debug("Exception while examining local running process: " + ex.Message);
             }
-            */
+            
             return VSConstants.S_FALSE;
         }
 


### PR DESCRIPTION
The changes to GetPhysicalProcessId in the remote attaching code broke local script running. This change fixes it. Explanation: local running needs a GUID, while remote attaching needs to have the remote process' pid. Thus, the fact that the ScriptDebugProcess created during local running doesn't have a PID is used to differentiate the two cases.

Pull request also contains re-enabling of local process attaching per convo with @AndreSayreMSFT.
