### PR TITLE
Remove New Line in Port Supplier Description.

### DIFF
--- a/PowerShellTools/Resources.Designer.cs
+++ b/PowerShellTools/Resources.Designer.cs
@@ -792,9 +792,7 @@ namespace PowerShellTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Allows for debugging of a PowerShell script on a remote machine. Utilizes PowerShell v5.0+ features. This version of PowerShell must be installed on the remote machine in order to remotely debug.
-        ///
-        ///Enter the name or address of the machine for which you wish to connect for the qualifier. There is no need to specify a transport protocol type (http, tcp, etc.), port number, or username..
+        ///   Looks up a localized string similar to Allows for debugging of a PowerShell script on a remote machine. Utilizes PowerShell v5.0+ features. This version of PowerShell must be installed on the remote machine in order to remotely debug. Enter the name or address of the machine for which you wish to connect for the qualifier. There is no need to specify a transport protocol type (http, tcp, etc.), port number, or username..
         /// </summary>
         public static string RemotePortDescription {
             get {

--- a/PowerShellTools/Resources.resx
+++ b/PowerShellTools/Resources.resx
@@ -397,9 +397,7 @@ Would you like to download now?</value>
     <value>ParameterSetName:</value>
   </data>
   <data name="RemotePortDescription" xml:space="preserve">
-    <value>Allows for debugging of a PowerShell script on a remote machine. Utilizes PowerShell v5.0+ features. This version of PowerShell must be installed on the remote machine in order to remotely debug.
-
-Enter the name or address of the machine for which you wish to connect for the qualifier. There is no need to specify a transport protocol type (http, tcp, etc.), port number, or username.</value>
+    <value>Allows for debugging of a PowerShell script on a remote machine. Utilizes PowerShell v5.0+ features. This version of PowerShell must be installed on the remote machine in order to remotely debug. Enter the name or address of the machine for which you wish to connect for the qualifier. There is no need to specify a transport protocol type (http, tcp, etc.), port number, or username.</value>
   </data>
   <data name="RemoteDebugTitle" xml:space="preserve">
     <value>PowerShell Tools Remote Debugging</value>


### PR DESCRIPTION
Turns out that the new line in the updated port supplier description pushes some of the description out of the text pane. This removes the new line.

Old:
![old](https://cloud.githubusercontent.com/assets/12631548/8942319/9028d770-3529-11e5-8d00-66c36ec21743.PNG)

With this fix:
![new](https://cloud.githubusercontent.com/assets/12631548/8939199/d01d974c-3517-11e5-8437-b76b9291acc7.PNG)
