### PR TITLE
Remote Debugging Filter Change and Azure Scenario Support

### DIFF
--- a/PowerShellTools.HostService/ServiceManagement/Debugging/PowerShellDebuggingService.cs
+++ b/PowerShellTools.HostService/ServiceManagement/Debugging/PowerShellDebuggingService.cs
@@ -185,7 +185,7 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
                 using (_currentPowerShell = PowerShell.Create())
                 {
                     // see if the process is a PS host
-                    if (InvokeScript(_currentPowerShell, string.Format("Get-PSHostProcessInfo -Id {0}", pid)).Count > 0)
+                    if (InvokeScript(_currentPowerShell, string.Format("Get-PSHostProcessInfo -Id {0}", pid)).Any())
                     {
                         var process = Process.GetProcessById((int)pid);
                         ServiceCommon.Log(string.Format("IsAttachable: {1}; id: {1}", process.ProcessName, process.Id));

--- a/PowerShellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingServiceUtilities.cs
+++ b/PowerShellTools.HostService/ServiceManagement/Debugging/PowershellDebuggingServiceUtilities.cs
@@ -381,7 +381,7 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
         /// <param name="powerShell">This should be an already instanstiated PowerShell object, and should be inside of a using. If
         /// powerShell is null, method will return without performing any action.</param>
         /// <param name="remoteName">Machine to connect to.</param>
-        private void EnterCredentialedRemoteSession(PowerShell powerShell, string remoteName)
+        private void EnterCredentialedRemoteSession(PowerShell powerShell, string remoteName, bool useSSL)
         {
             if (powerShell == null)
             {
@@ -395,13 +395,26 @@ namespace PowerShellTools.HostService.ServiceManagement.Debugging
                 return;
             }
 
+            string port = remoteName.Split(':').ElementAtOrDefault(1);
+
             PSCommand enterSession = new PSCommand();
             enterSession.AddCommand("Enter-PSSession").AddParameter("ComputerName", remoteName).AddParameter("Credential", _savedCredential);
+
+            if (port != null)
+            {
+                // check for user specified port
+                enterSession.AddParameter("-Port", port);
+            }
+            if (useSSL)
+            {
+                // if told to use SSL from options dialog, add the SSL parameter
+                enterSession.AddParameter("-UseSSL");
+            }
+
             powerShell.Runspace = _runspace;
             powerShell.Commands.Clear();
             powerShell.Commands = enterSession;
             powerShell.Invoke();
         }
-
     }
 }

--- a/PowerShellTools/DebugEngine/Remote/IPowerShellToolsPortSupplier.cs
+++ b/PowerShellTools/DebugEngine/Remote/IPowerShellToolsPortSupplier.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Debugger.Interop;
+
+namespace PowerShellTools.DebugEngine.Remote
+{
+    /// <summary>
+    /// Interface for all remote debugging port suppliers that this tool implements. Enforces the
+    /// need for said port suppliers to specify whether or not the -UseSSL parameter should be used
+    /// when entering into a remote session with a machine.
+    /// </summary>
+    interface IPowerShellToolsPortSupplier : IDebugPortSupplier2, IDebugPortSupplierDescription2
+    {
+        bool UsesSSL();
+    }
+}

--- a/PowerShellTools/DebugEngine/Remote/RemoteDebugPort.cs
+++ b/PowerShellTools/DebugEngine/Remote/RemoteDebugPort.cs
@@ -14,12 +14,12 @@ namespace PowerShellTools.DebugEngine.Remote
     /// </summary>
     internal class RemoteDebugPort : IDebugPort2
     {
-        private readonly RemoteDebugPortSupplier _supplier;
+        private readonly IPowerShellToolsPortSupplier _supplier;
         private readonly IDebugPortRequest2 _request;
         private readonly Guid _guid = Guid.NewGuid();
         private readonly string _computerName;
 
-        public RemoteDebugPort(RemoteDebugPortSupplier supplier, IDebugPortRequest2 request, string computerName)
+        public RemoteDebugPort(IPowerShellToolsPortSupplier supplier, IDebugPortRequest2 request, string computerName)
         {
             _supplier = supplier;
             _request = request;
@@ -34,7 +34,7 @@ namespace PowerShellTools.DebugEngine.Remote
         public int EnumProcesses(out IEnumDebugProcesses2 ppEnum)
         {
             RemoteEnumDebugProcess processList = new RemoteEnumDebugProcess(_computerName);
-            processList.connect(this);
+            processList.connect(this, _supplier.UsesSSL());
             ppEnum = processList;
             return VSConstants.S_OK;
         }
@@ -66,7 +66,7 @@ namespace PowerShellTools.DebugEngine.Remote
         public int GetProcess(AD_PROCESS_ID ProcessId, out IDebugProcess2 ppProcess)
         {
             RemoteEnumDebugProcess processList = new RemoteEnumDebugProcess(_computerName);
-            processList.connect(this);
+            processList.connect(this, _supplier.UsesSSL());
             uint numProcesses = 0;
             uint numRetrieved = 0;
             ppProcess = null;

--- a/PowerShellTools/DebugEngine/Remote/RemoteEnumDebugProcess.cs
+++ b/PowerShellTools/DebugEngine/Remote/RemoteEnumDebugProcess.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Debugger.Interop;
 using PowerShellTools.Common;
 using PowerShellTools.Common.ServiceManagement.DebuggingContract;
+using PowerShellTools.Options;
 
 namespace PowerShellTools.DebugEngine.Remote
 {
@@ -38,10 +39,8 @@ namespace PowerShellTools.DebugEngine.Remote
         /// the call to EnumerateRemoteProcesses returns null.
         /// </summary>
         /// <param name="remotePort"></param>
-        public void connect(IDebugPort2 remotePort)
+        public void connect(IDebugPort2 remotePort, bool useSSL)
         {
-            
-
             // Make sure user is starting from a local scenario
             DebugScenario scenario = PowerShellToolsPackage.Debugger.DebuggingService.GetDebugScenario();
             if (scenario != DebugScenario.Local)
@@ -71,7 +70,7 @@ namespace PowerShellTools.DebugEngine.Remote
                 while (true)
                 {
                     Log.Debug(string.Format("Attempting to find processes on {0}.", _remoteComputer));
-                    information = PowerShellToolsPackage.Debugger.DebuggingService.EnumerateRemoteProcesses(_remoteComputer, ref errorMessage);
+                    information = PowerShellToolsPackage.Debugger.DebuggingService.EnumerateRemoteProcesses(_remoteComputer, ref errorMessage, useSSL);
 
                     if (information != null)
                     {

--- a/PowerShellTools/DebugEngine/Remote/RemoteUnsecuredDebugPortSupplier.cs
+++ b/PowerShellTools/DebugEngine/Remote/RemoteUnsecuredDebugPortSupplier.cs
@@ -7,13 +7,14 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Debugger.Interop;
 using PowerShellTools.Common;
 
+
 namespace PowerShellTools.DebugEngine.Remote
 {
     /// <summary>
-    /// Supplies the PowerShell Tools remote debugging transport to the
+    /// Supplies the PowerShell Tools unsecured remote debugging transport to the
     /// attach to process dialog.
     /// </summary>
-    internal class RemoteDebugPortSupplier : IPowerShellToolsPortSupplier
+    internal class RemoteUnsecuredDebugPortSupplier : IPowerShellToolsPortSupplier
     {
         public int AddPort(IDebugPortRequest2 pRequest, out IDebugPort2 ppPort)
         {
@@ -28,7 +29,7 @@ namespace PowerShellTools.DebugEngine.Remote
 
         public bool UsesSSL()
         {
-            return true;
+            return false;
         }
 
         public int CanAddPort()
@@ -39,12 +40,12 @@ namespace PowerShellTools.DebugEngine.Remote
         public int EnumPorts(out IEnumDebugPorts2 ppEnum)
         {
             ppEnum = null;
-            return VSConstants.S_OK;   
+            return VSConstants.S_OK;
         }
 
         public int GetDescription(enum_PORT_SUPPLIER_DESCRIPTION_FLAGS[] pdwFlags, out string pbstrText)
         {
-            pbstrText = Resources.RemotePortDescription;
+            pbstrText = Resources.RemoteUnsecuredPortDescription;
             return VSConstants.S_OK;
         }
 
@@ -62,7 +63,7 @@ namespace PowerShellTools.DebugEngine.Remote
 
         public int GetPortSupplierName(out string pbstrName)
         {
-            pbstrName = Resources.RemoteDebugTitle;
+            pbstrName = Resources.RemoteUnsecuredDebugTitle;
             return VSConstants.S_OK;
         }
 

--- a/PowerShellTools/DebugEngine/Remote/RemoteUnsecuredPortPicker.cs
+++ b/PowerShellTools/DebugEngine/Remote/RemoteUnsecuredPortPicker.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Debugger.Interop;
+using Microsoft.VisualStudio.OLE.Interop;
+
+namespace PowerShellTools.DebugEngine.Remote
+{
+    /// <summary>
+    /// Class is utilized by Visual Studio when the Attach to Process dialog is active and the PowerShell Tools
+    /// unsecured remote debugging option is selected.
+    /// </summary>
+    internal class RemoteUnsecuredPortPicker : IDebugPortPicker
+    {
+        public int DisplayPortPicker(IntPtr hwndParentDialog, out string pbstrPortId)
+        {
+            pbstrPortId = null;
+            return VSConstants.E_NOTIMPL;
+        }
+
+        public int SetSite(Microsoft.VisualStudio.OLE.Interop.IServiceProvider pSP)
+        {
+            return VSConstants.E_NOTIMPL;
+        }
+    }
+}

--- a/PowerShellTools/PowerShellTools.csproj
+++ b/PowerShellTools/PowerShellTools.csproj
@@ -277,11 +277,14 @@
       <DependentUpon>ReadHostPromptForChoicesView.xaml</DependentUpon>
     </Compile>
     <Compile Include="DebugEngine\PromptUI\ReadHostPromptForChoicesViewModel.cs" />
+    <Compile Include="DebugEngine\Remote\IPowerShellToolsPortSupplier.cs" />
     <Compile Include="DebugEngine\Remote\RemoteDebugPort.cs" />
     <Compile Include="DebugEngine\Remote\RemoteDebugPortSupplier.cs" />
     <Compile Include="DebugEngine\Remote\RemoteEnumDebugProcess.cs" />
     <Compile Include="DebugEngine\Remote\RemoteEnumDebugPrograms.cs" />
+    <Compile Include="DebugEngine\Remote\RemoteUnsecuredPortPicker.cs" />
     <Compile Include="DebugEngine\Remote\RemotePortPicker.cs" />
+    <Compile Include="DebugEngine\Remote\RemoteUnsecuredDebugPortSupplier.cs" />
     <Compile Include="DebugServiceEventHandlerBehaviorAttribute.cs" />
     <Compile Include="DebugEngine\DebugServiceEventsHandlerProxy.cs" />
     <Compile Include="DebugEngine\Definitions\Com.cs" />

--- a/PowerShellTools/PowerShellToolsPackage.cs
+++ b/PowerShellTools/PowerShellToolsPackage.cs
@@ -112,7 +112,8 @@ namespace PowerShellTools
         @"%TestDocs%\Code Snippets\PowerShel\SnippetsIndex.xml",  // Path to snippets index
         SearchPaths = @"%TestDocs%\Code Snippets\PowerShell\")]    // Path to snippets
 
-    [ProvideDebugPortSupplier("Powershell Remote Debugging", typeof(RemoteDebugPortSupplier), PowerShellTools.Common.Constants.PortSupplierId, typeof(RemotePortPicker))]
+    [ProvideDebugPortSupplier("Powershell Remote Debugging (SSL Required)", typeof(RemoteDebugPortSupplier), PowerShellTools.Common.Constants.PortSupplierId, typeof(RemotePortPicker))]
+    [ProvideDebugPortSupplier("Powershell Remote Debugging", typeof(RemoteUnsecuredDebugPortSupplier), PowerShellTools.Common.Constants.UnsecuredPortSupplierId, typeof(RemoteUnsecuredPortPicker))]
     [ProvideDebugPortPicker(typeof(RemotePortPicker))]
 
     public sealed class PowerShellToolsPackage : CommonPackage

--- a/PowerShellTools/Resources.Designer.cs
+++ b/PowerShellTools/Resources.Designer.cs
@@ -810,7 +810,7 @@ namespace PowerShellTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Allows for debugging of a PowerShell script on a remote machine. Enter the name or address of the machine for which you wish to connect for the qualifier. Port 5986 is the default port but another may be specified. There is no need to specify a transport protocol type (http, tcp, etc.) or username. PowerShell v5.0+ must be installed on the remote machine. Does not require a SSL certificate..
+        ///   Looks up a localized string similar to Allows for debugging of a PowerShell script on a remote machine. Enter the name or address of the machine for which you wish to connect for the qualifier. Port 5985 is the default port but another may be specified. There is no need to specify a transport protocol type (http, tcp, etc.) or username. PowerShell v5.0+ must be installed on the remote machine. Does not require a SSL certificate..
         /// </summary>
         public static string RemoteUnsecuredPortDescription {
             get {

--- a/PowerShellTools/Resources.Designer.cs
+++ b/PowerShellTools/Resources.Designer.cs
@@ -783,7 +783,7 @@ namespace PowerShellTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to PowerShell Tools Remote Debugging.
+        ///   Looks up a localized string similar to PowerShell Tools Remote Debugging (SSL Required).
         /// </summary>
         public static string RemoteDebugTitle {
             get {
@@ -792,11 +792,29 @@ namespace PowerShellTools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Allows for debugging of a PowerShell script on a remote machine. Utilizes PowerShell v5.0+ features. This version of PowerShell must be installed on the remote machine in order to remotely debug. Enter the name or address of the machine for which you wish to connect for the qualifier. There is no need to specify a transport protocol type (http, tcp, etc.), port number, or username..
+        ///   Looks up a localized string similar to Allows for debugging of a PowerShell script on a remote machine. Enter the name or address of the machine for which you wish to connect for the qualifier. Port 5986 is the default port but another may be specified. There is no need to specify a transport protocol type (http, tcp, etc.) or username. PowerShell v5.0+ must be installed on the remote machine. Requires a SSL certificate..
         /// </summary>
         public static string RemotePortDescription {
             get {
                 return ResourceManager.GetString("RemotePortDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PowerShell Tools Remote Debugging.
+        /// </summary>
+        public static string RemoteUnsecuredDebugTitle {
+            get {
+                return ResourceManager.GetString("RemoteUnsecuredDebugTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Allows for debugging of a PowerShell script on a remote machine. Enter the name or address of the machine for which you wish to connect for the qualifier. Port 5986 is the default port but another may be specified. There is no need to specify a transport protocol type (http, tcp, etc.) or username. PowerShell v5.0+ must be installed on the remote machine. Does not require a SSL certificate..
+        /// </summary>
+        public static string RemoteUnsecuredPortDescription {
+            get {
+                return ResourceManager.GetString("RemoteUnsecuredPortDescription", resourceCulture);
             }
         }
         

--- a/PowerShellTools/Resources.resx
+++ b/PowerShellTools/Resources.resx
@@ -397,10 +397,10 @@ Would you like to download now?</value>
     <value>ParameterSetName:</value>
   </data>
   <data name="RemotePortDescription" xml:space="preserve">
-    <value>Allows for debugging of a PowerShell script on a remote machine. Utilizes PowerShell v5.0+ features. This version of PowerShell must be installed on the remote machine in order to remotely debug. Enter the name or address of the machine for which you wish to connect for the qualifier. There is no need to specify a transport protocol type (http, tcp, etc.), port number, or username.</value>
+    <value>Allows for debugging of a PowerShell script on a remote machine. Enter the name or address of the machine for which you wish to connect for the qualifier. Port 5986 is the default port but another may be specified. There is no need to specify a transport protocol type (http, tcp, etc.) or username. PowerShell v5.0+ must be installed on the remote machine. Requires a SSL certificate.</value>
   </data>
   <data name="RemoteDebugTitle" xml:space="preserve">
-    <value>PowerShell Tools Remote Debugging</value>
+    <value>PowerShell Tools Remote Debugging (SSL Required)</value>
   </data>
   <data name="AttachErrorTitle" xml:space="preserve">
     <value>Error Attaching to Process</value>
@@ -416,5 +416,11 @@ Would you like to download now?</value>
   </data>
   <data name="AttachExistingRemoteError" xml:space="preserve">
     <value>Cannot remotely debug a process while in a remote session. Please exit your remote session before trying again.</value>
+  </data>
+  <data name="RemoteUnsecuredDebugTitle" xml:space="preserve">
+    <value>PowerShell Tools Remote Debugging</value>
+  </data>
+  <data name="RemoteUnsecuredPortDescription" xml:space="preserve">
+    <value>Allows for debugging of a PowerShell script on a remote machine. Enter the name or address of the machine for which you wish to connect for the qualifier. Port 5986 is the default port but another may be specified. There is no need to specify a transport protocol type (http, tcp, etc.) or username. PowerShell v5.0+ must be installed on the remote machine. Does not require a SSL certificate.</value>
   </data>
 </root>

--- a/PowerShellTools/Resources.resx
+++ b/PowerShellTools/Resources.resx
@@ -421,6 +421,6 @@ Would you like to download now?</value>
     <value>PowerShell Tools Remote Debugging</value>
   </data>
   <data name="RemoteUnsecuredPortDescription" xml:space="preserve">
-    <value>Allows for debugging of a PowerShell script on a remote machine. Enter the name or address of the machine for which you wish to connect for the qualifier. Port 5986 is the default port but another may be specified. There is no need to specify a transport protocol type (http, tcp, etc.) or username. PowerShell v5.0+ must be installed on the remote machine. Does not require a SSL certificate.</value>
+    <value>Allows for debugging of a PowerShell script on a remote machine. Enter the name or address of the machine for which you wish to connect for the qualifier. Port 5985 is the default port but another may be specified. There is no need to specify a transport protocol type (http, tcp, etc.) or username. PowerShell v5.0+ must be installed on the remote machine. Does not require a SSL certificate.</value>
   </data>
 </root>

--- a/PowershellTools.Common/Constants.cs
+++ b/PowershellTools.Common/Constants.cs
@@ -99,5 +99,15 @@ namespace PowerShellTools.Common
         /// This is the GUID for the PowerShell Tools remote debugging port supplier.
         /// </summary>
         public static readonly Guid PortSupplierGuid = new Guid(PortSupplierId);
+
+        /// <summary>
+        /// This is the GUID in string form for the PowerShell Tools unsecured remote debugging port supplier.
+        /// </summary>
+        public const string UnsecuredPortSupplierId = "{44379988-7b12-4cfe-b02a-d56f751d597a}";
+
+        /// <summary>
+        /// This is the GUID for the PowerShell Tools unsecured remote debugging port supplier.
+        /// </summary>
+        public static readonly Guid UnsecuredPortSupplierGuid = new Guid(UnsecuredPortSupplierId);
     }
 }

--- a/PowershellTools.Common/ServiceManagement/DebuggingContract/IPowershellDebuggingService.cs
+++ b/PowershellTools.Common/ServiceManagement/DebuggingContract/IPowershellDebuggingService.cs
@@ -54,7 +54,7 @@ namespace PowerShellTools.Common.ServiceManagement.DebuggingContract
         bool DetachFromRunspace();
 
         [OperationContract]
-        List<KeyValuePair<uint, string>> EnumerateRemoteProcesses(string remoteMachine, ref string errorMessage);
+        List<KeyValuePair<uint, string>> EnumerateRemoteProcesses(string remoteMachine, ref string errorMessage, bool useSSL);
 
         [OperationContract]
         string AttachToRemoteRunspace(uint pid, string remoteName);


### PR DESCRIPTION
Changed attachable logic to use Get-PSHostProcessInfo as the filter for finding attachable processes. This is much more accurate than looking for the powershell.exe module. Added an alternative remote debugging transport which utilizes SSL. This will allow users to connect to Azure VMs. Also added the ability to specify a port. Not a very likely scenario, but Azure lets you change the PowerShell connection port so it may be useful to some users.

Resolves #673 

@EricMSFT @AndreSayreMSFT @HuanhuanSunMSFT 
