### PR TITLE
Progress Bar Fix

### DIFF
--- a/PowerShellTools/DebugEngine/HostUi.cs
+++ b/PowerShellTools/DebugEngine/HostUi.cs
@@ -177,9 +177,13 @@ namespace PowerShellTools.DebugEngine
                 {
                     case ProgressRecordType.Processing:
                         {
-                            if (record.PercentComplete >= 0)
+                            if (record.PercentComplete >= 0 && record.PercentComplete < 100)
                             {
                                 statusBar.Progress(ref cookie, 1, label, (uint)record.PercentComplete, 100);
+                            }
+                            else if (record.PercentComplete == 100)
+                            {
+                                statusBar.Progress(ref cookie, 1, "", 0, 0);
                             }
                             else
                             {


### PR DESCRIPTION
It seems that PowerShell cmdlets like to send ProgressRecords with a type of "Processing" but that also have a 100% complete status. This was not being handled and resulted in us displaying a full progress bar that never went away. This case is now handled in the same way that a ProgressRecord with a "Complete" type are handled.

Resolves #249

@AndreSayreMSFT @HuanhuanSunMSFT 
