### PR TITLE
Execute As Script Keyboard Shortcut Change

### DIFF
--- a/PowerShellTools/PowerShellTools.vsct
+++ b/PowerShellTools/PowerShellTools.vsct
@@ -5,8 +5,8 @@
   <Extern href="vsshlids.h"/>
 
   <KeyBindings>
-    <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidExecuteAsScript" editor="guidVSStd97" key1="0x45" key2="VK_F5" mod1="Shift"/>
-    <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidExecuteWithParametersAsScript" editor="guidVSStd97" key1="0x45" key2="VK_F5" mod1="Shift Alt"/>
+    <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidExecuteAsScript" editor="guidVSStd97" key1="e" key2="VK_F5" mod1="Shift"/>
+    <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidExecuteWithParametersAsScript" editor="guidVSStd97" key1="e" key2="VK_F5" mod1="Shift Alt"/>
     <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidExecuteSelection" editor="guidVSStd97" key1="VK_F8" mod1="Control"/>
     <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidReplWindow" editor="guidVSStd97" key1="VK_OEM_5" mod1="Control Shift"/>
   </KeyBindings>

--- a/PowerShellTools/PowerShellTools.vsct
+++ b/PowerShellTools/PowerShellTools.vsct
@@ -5,8 +5,8 @@
   <Extern href="vsshlids.h"/>
 
   <KeyBindings>
-    <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidExecuteAsScript" editor="guidVSStd97" key1="VK_F5" mod1="Alt Shift"/>
-    <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidExecuteWithParametersAsScript" editor="guidVSStd97" key1="VK_F5" mod1="Control Alt Shift"/>
+    <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidExecuteAsScript" editor="guidVSStd97" key1="0x58" key2="VK_F5" mod1="Shift Alt"/>
+    <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidExecuteWithParametersAsScript" editor="guidVSStd97" key1="0x58" key2="VK_F5" mod1="Control Alt Shift"/>
     <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidExecuteSelection" editor="guidVSStd97" key1="VK_F8" mod1="Control"/>
     <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidReplWindow" editor="guidVSStd97" key1="VK_OEM_5" mod1="Control Shift"/>
   </KeyBindings>

--- a/PowerShellTools/PowerShellTools.vsct
+++ b/PowerShellTools/PowerShellTools.vsct
@@ -5,8 +5,8 @@
   <Extern href="vsshlids.h"/>
 
   <KeyBindings>
-    <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidExecuteAsScript" editor="guidVSStd97" key1="0x58" key2="VK_F5" mod1="Shift Alt"/>
-    <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidExecuteWithParametersAsScript" editor="guidVSStd97" key1="0x58" key2="VK_F5" mod1="Control Alt Shift"/>
+    <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidExecuteAsScript" editor="guidVSStd97" key1="0x45" key2="VK_F5" mod1="Shift"/>
+    <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidExecuteWithParametersAsScript" editor="guidVSStd97" key1="0x45" key2="VK_F5" mod1="Shift Alt"/>
     <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidExecuteSelection" editor="guidVSStd97" key1="VK_F8" mod1="Control"/>
     <KeyBinding guid="guidPoshToolsCmdSet" id="cmdidReplWindow" editor="guidVSStd97" key1="VK_OEM_5" mod1="Control Shift"/>
   </KeyBindings>


### PR DESCRIPTION
It was reported to us in #629 that our keyboard shortcut for "Execute with Script" conflicted with a shortcut in PTVS. Thus, this pull request changes that shortcut.

It is now: 
shift+E, f5 (so you do the first 2, let go, and then the f5)

And since that was changed, "Execute as Script with Parameters" is now:
shift+alt+E, f5. 

Please provide feedback/alternative shortcut ideas if you have them.

@jinglou- @AndreSayreMSFT @HuanhuanSunMSFT 
