### PR TITLE
Removing OutputString Event Handler

### DIFF
--- a/PowerShellTools.Test/ScriptDebuggerTest.cs
+++ b/PowerShellTools.Test/ScriptDebuggerTest.cs
@@ -194,7 +194,6 @@ namespace PowerShellTools.Test
             var mre = new ManualResetEvent(false);
             string outputString = null;
             _debugger.DebuggingFinished += (sender, args) => mre.Set();
-            _debugger.OutputString += (sender, args) => outputString = args.Value;
             _debugger.Execute(node);
 
             Assert.IsTrue(mre.WaitOne(5000));

--- a/PowerShellTools/DebugEngine/Engine.cs
+++ b/PowerShellTools/DebugEngine/Engine.cs
@@ -106,7 +106,6 @@ namespace PowerShellTools.DebugEngine
             }
 
             Debugger.HostUi.OutputString = _events.OutputString;
-            Debugger.OutputString += Debugger_OutputString;
             Debugger.BreakpointManager.BreakpointHit += Debugger_BreakpointHit;
             Debugger.DebuggingBegin += Debugger_DebuggingBegin;
             Debugger.DebuggingFinished += Debugger_DebuggingFinished;

--- a/PowerShellTools/DebugEngine/ScriptDebugger.cs
+++ b/PowerShellTools/DebugEngine/ScriptDebugger.cs
@@ -43,11 +43,6 @@ namespace PowerShellTools.DebugEngine
         public event EventHandler<EventArgs<ScriptLocation>> DebuggerPaused;
 
         /// <summary>
-        /// Event is fired when a string is output from the PowerShell host.
-        /// </summary>
-        public event EventHandler<EventArgs<string>> OutputString;
-
-        /// <summary>
         /// Event is fired when the debugger has finished.
         /// </summary>
         public event EventHandler DebuggingFinished;


### PR DESCRIPTION
Resolves #600. On a related note, we still need to fix the ShouldSupportRemoteSession test (#252). May take that task pending time.

@EricMSFT @AndreSayreMSFT @HuanhuanSunMSFT 
