### PR TITLE
Prompt Is Now Displayed In The REPL Before Each Execution

### DIFF
--- a/PowerShellTools/DebugEngine/ScriptDebugger.cs
+++ b/PowerShellTools/DebugEngine/ScriptDebugger.cs
@@ -440,7 +440,7 @@ namespace PowerShellTools.DebugEngine
                 if (node.IsFile)
                 {
                     commandLine = String.Format(DebugEngineConstants.ExecutionCommandFormat, node.FileName, node.Arguments);
-                    HostUi.VsOutputString(string.Format("{0}{1}", GetPrompt(), node.FileName) + Environment.NewLine);
+                    HostUi.VsOutputString(string.Format("{0}{1}{2}", GetPrompt(), node.FileName, Environment.NewLine));
                 }
                 Execute(commandLine);
             }

--- a/PowerShellTools/DebugEngine/ScriptDebugger.cs
+++ b/PowerShellTools/DebugEngine/ScriptDebugger.cs
@@ -440,6 +440,7 @@ namespace PowerShellTools.DebugEngine
                 if (node.IsFile)
                 {
                     commandLine = String.Format(DebugEngineConstants.ExecutionCommandFormat, node.FileName, node.Arguments);
+                    HostUi.VsOutputString(string.Format("{0}{1}", GetPrompt(), node.FileName) + Environment.NewLine);
                 }
                 Execute(commandLine);
             }


### PR DESCRIPTION
The prompt is now printed out before execution and the file being executed is printed out as well. 

![new](https://cloud.githubusercontent.com/assets/12631548/9043720/4b3f36e8-39cc-11e5-96bb-5582c30a05cc.PNG)

@HuanhuanSunMSFT @AndreSayreMSFT 

Resolves #367, #564 
